### PR TITLE
[Feature] Melhoria na visualização de dados no portal admin

### DIFF
--- a/lanternaverde_web/admin.py
+++ b/lanternaverde_web/admin.py
@@ -3,11 +3,37 @@ from .models import Pergunta, Usuario, Administrador, Analista, AvaliacaoAnalist
 
 
 # Register your models here.
-admin.site.register(Usuario)
-admin.site.register(Administrador)
-admin.site.register(Analista)
-admin.site.register(AvaliacaoAnalista)
-admin.site.register(Pergunta)
-admin.site.register(Questao)
-admin.site.register(Empresa)
 
+@admin.register(Usuario)
+class UsuarioAdmin(admin.ModelAdmin):
+    list_display = ['email', 'username']
+
+
+@admin.register(Administrador)
+class AdministradorAdmin(admin.ModelAdmin):
+    list_display = ['user', 'role']
+
+
+@admin.register(Analista)
+class AnalistaAdmin(admin.ModelAdmin):
+    list_display = ['user', 'specialty', 'available', 'cpf']
+
+
+@admin.register(AvaliacaoAnalista)
+class AvaliacaoAnalistaAdmin(admin.ModelAdmin):
+    list_display = ['analyst', 'company', 'score', 'finished']
+
+
+@admin.register(Pergunta)
+class PerguntaAdmin(admin.ModelAdmin):
+    list_display = ['body', 'dimension']
+
+
+@admin.register(Questao)
+class QuestaoAdmin(admin.ModelAdmin):
+    list_display = ['questionnaire', 'question', 'answer']
+
+
+@admin.register(Empresa)
+class EmpresaAdmin(admin.ModelAdmin):
+    list_display = ['user', 'tradeName', 'cnpj', 'tipo']

--- a/lanternaverde_web/models.py
+++ b/lanternaverde_web/models.py
@@ -114,6 +114,8 @@ class Analista(models.Model):
     class Meta:
         verbose_name = 'analista'
         verbose_name_plural = 'analistas'
+    def __str__(self):
+        return self.user.username
 
 class Empresa(models.Model):
     TYPE = (
@@ -135,6 +137,8 @@ class Empresa(models.Model):
     class Meta:
         verbose_name = 'empresa'
         verbose_name_plural = 'empresas'
+    def __str__(self):
+        return self.tradeName
 
 class Pergunta(models.Model):
     """
@@ -162,6 +166,8 @@ class Pergunta(models.Model):
         """database metadata"""
         verbose_name = 'Pergunta'
         verbose_name_plural = 'Perguntas'
+    def __str__(self):
+        return self.body
 
 class AvaliacaoAnalista(models.Model):
     analyst = models.ForeignKey(Analista, related_name='analises', on_delete=models.CASCADE)
@@ -169,6 +175,9 @@ class AvaliacaoAnalista(models.Model):
     score = models.FloatField(default=0)
     comment = models.TextField(blank=True)
     finished = models.BooleanField(default=False)
+
+    def __str__(self):
+        return self.analyst.user.username + ' -> ' + self.company.tradeName
 
 
 class Questao(models.Model):


### PR DESCRIPTION
<!-- Está criando uma Pull Request pela primeira vez? Deixe esse modelo guiar você -->

Esta é uma melhoria na visualização da relação de dados no portal de administrador do Django
<!-- Nesse campo faça um pequeno sumário das suas implementações e seja breve, deixe para detalhar nos campos mais específicos. -->

## Problema

No portal de administrador do Django as tabelas de modelos não mostram os valores do objeto, tornando difícil saber à primeira vista de qual objeto se trata cada linha

## Implementação

Para melhorar esta visualização utilizei uma notação diferente da que já vínhamos usando para registrar os modelos no portal admin, para mostrar os dados de uma maneira mais amigável, além de configurar a representação textual de um objeto de cada modelo (o famoso `toString()` de java, ou no nosso caso, o `__str__()` do python`)

### Dessa forma, a representação dos modelos foi disso
```python
admin.site.register(Analista)
```
![image](https://user-images.githubusercontent.com/74150316/188252063-dabf4a16-0e16-48c5-adc8-edb496461381.png)


### Para isso
```python
@admin.register(Analista)
class AnalistaAdmin(admin.ModelAdmin):
    list_display = ['user', 'specialty', 'available', 'cpf']

```
![image](https://user-images.githubusercontent.com/74150316/188252133-42223c10-9d8c-40e6-a8b0-4c046b6299f1.png)
