### PR TITLE
[Feature] Método que lista análises de uma determinada empresa

### DIFF
--- a/lanternaverde_web/urls.py
+++ b/lanternaverde_web/urls.py
@@ -24,8 +24,8 @@ urlpatterns = [
     path('solicitacoesAnalise/detail', views.get_solicitacao, name='Get Solicitação Análise'),
     path('solicitacoesAnalise/analises', views.get_analysis_by_request, name='get_analysis_by_request'),
 
-
     path('analise', views.listar_analises, name='listar_analises'),
+    path('analise/empresa', views.listar_analises_empresa, name='listar_analises_empresa'),
     path('analise/add', views.criar_analise, name='criar_analise'),
     path('analise/detail', views.detalhar_analise, name='detalhar_analise'),
     path('analise/update', views.atualizar_analise, name='atualizar_analise'),

--- a/lanternaverde_web/views.py
+++ b/lanternaverde_web/views.py
@@ -269,6 +269,15 @@ def listar_analises(request):
     """
     return avalAnalista.listar_analises(request)
 
+@login_required
+@administrador_required
+def listar_analises_empresa(request):
+    """
+    Method that groups `AvaliacaoAnalista` from a specific company into a JSON
+    response.
+    """
+    return avalAnalista.listar_analises_empresa(request)
+
 @csrf_exempt
 @login_required
 def detalhar_analise(request):


### PR DESCRIPTION
Nessa Pull Request é criado um método que lista todas as análises de uma determinada empresa

## Problema

Detalhado em #66.

## Implementação

Cria um novo método que consulta uma determinada empresa e também todas as suas análises já criadas (HTTP Response: código de sucesso 200). Caso a empresa nunca tenha sido analisada, o método retorna um erro semântico (HTTP Response: código de erro 422 e a mensagem: _"A empresa solicitada nunca foi analisada por analistas"_).

## Como Testar

É necessário realizar o teste por meio do Postman.

1. Logue por meio do Postman, com um usuário com a especialidade de Administrador;
2. Crie um request do tipo `GET`;
3. No campo body, crie um body do tipo `raw`;
4. Ao invés do tipo `Text`, selecione o tipo `JSON`;
5. Insira o campo abaixo, substituindo a variável `x` pelo ID da empresa.
    ```JSON
    {
      "companyid": x
    }
    ```

## Notas do desenvolvedor

@Engenharia-de-Software-UFRPE/joyces-frontend, qualquer bronca pode mandar brasa nessa PR.

## Objetivos

Fixes #66 