### PR TITLE
tela de responder análise e tela de visualização atualizadas

### DIFF
--- a/Frontend/src/components/Analyst/analysis/Questions.js
+++ b/Frontend/src/components/Analyst/analysis/Questions.js
@@ -26,6 +26,7 @@ const Questions = ({ questao, analysis, setDimensions, handleCheckBoxClick, hand
     //     // console.log(questao.question.dimension)
     // }
 
+    const [active, setActive] = useState(questao.answer);
 
     function sourceAreaChange() {
         let sourceValue = document.getElementById("questionSource"+questao.id).value
@@ -36,20 +37,29 @@ const Questions = ({ questao, analysis, setDimensions, handleCheckBoxClick, hand
         let justificationValue = document.getElementById("questionJustification"+questao.id).value
         handleJustificationChange(justificationValue,questao)
     }
+
+    function CheckBoxClicked(questao) {
+        setActive((prevState) => !prevState);
+        handleCheckBoxClick(questao)
+    }
     return <>
             <div className='listQuestoes'>
                 {/* <div className='question-and-awnser'> */}
                         Questão: {questao.question.body} 
                         <label class="switch">
-                            <input type="checkbox" onClickCapture={() => handleCheckBoxClick(questao)} defaultChecked={questao.answer}>
+                            <input type="checkbox" onClickCapture={() => CheckBoxClicked(questao)} defaultChecked={questao.answer}>
                             </input>
                             <span class="slider round">
                             </span>
                         </label> 
                 {/* </div> */}
             </div>
+            {active ? 
+            <>
             Fonte:<br></br> <textarea  className='sourceArea' id = {'questionSource'+questao.id} onChange={sourceAreaChange}>{questao.source}</textarea> <br></br>
             Justificativa:<br></br> <textarea  className='justificationArea' id = {'questionJustification'+questao.id} onChange={justificationAreaChange}>{questao.justification}</textarea>  <br></br>
+            </> 
+            : <></>}
             </>
 }; 
 

--- a/Frontend/src/components/Analyst/analysis/QuestionsFinished.js
+++ b/Frontend/src/components/Analyst/analysis/QuestionsFinished.js
@@ -13,8 +13,14 @@ const QuestionsFinished = ({ questao }) => {
                 </label> 
         
             </div>
+        
+        {questao.answer ? 
+        <>
         Fonte:<br></br> <textarea readonly  = 'true' className='sourceArea' id = {'questionSource'+questao.id} >{questao.source}</textarea> <br></br>
         Justificativa:<br></br> <textarea readonly = 'true'  className='justificationArea' id = {'questionJustification'+questao.id}>{questao.justification}</textarea>  <br></br>
+        </> 
+        : <></>}
+
         </>
 }; 
 


### PR DESCRIPTION
Agora os campos de justificativa e fonte só serão mostrandos quando a alternativa da questão estiver marcada como verdadeira. Isso poupa espaço e deixa o questionário mais limpo.


## Problema

Antigamente, indepente da resposta da questão (afirmativa ou negativa) os campos para o preenchimento ou visualização da justificativa e da fonte sempre eram mostrados.


## Como Testar

Basta ir na tela para fazer análise ou visualizar uma análise pendente (na tela do analista) e ver se os campos que estão com uma resposta negativa não mostram os campos de justificativa e fonte. Faça uma análise e marque um dos campos como verdadeiro e veja se os campos aparecem

![image](https://user-images.githubusercontent.com/84993974/194072450-8fef5afa-bfb5-4982-af63-e4a5e50a66f3.png)


## Notas do desenvolvedor

Aceita ai adm

## Objetivos

Deixar as páginas menos poluidas visualmente com campos em branco que nunca vão ser preenchidos (nas respostas negativas).
