### PR TITLE
[Feature] Métodos Públicos para Listar e Detalhar Empresa

### DIFF
--- a/lanternaverde_web/empresa.py
+++ b/lanternaverde_web/empresa.py
@@ -1,0 +1,37 @@
+from .models import Empresa
+import json
+from .serializers import EmpresaSerializer, EmpresaPublicSerializer
+from .utils.jsonresponse import JSONResponse
+from django.http import HttpResponse, HttpResponseBadRequest
+
+
+def detalhar_empresa(request):
+    """
+    Método para detalhar uma empresa sem necessariamente estar logado (visão do consumidor)
+    """
+    if request.method == 'GET':
+        data = request.GET
+        try:
+            empresa = Empresa.objects.get(pk=data.get('companyid'))
+        except Exception as error:
+            return HttpResponse(error, status=404)
+        ser_empresa = EmpresaPublicSerializer(empresa).data
+        ser_return = {
+            "Empresa": ser_empresa
+        }
+        return JSONResponse(ser_return, status=200)
+    return HttpResponseBadRequest()
+
+
+def listar_empresas(request):
+    if request.method == 'GET':
+        #pylint: disable=E1101
+        if hasattr(request.user, 'administrador'):
+            empresas = EmpresaSerializer(Empresa.objects.all(), many=True)
+        else:
+            empresas = EmpresaPublicSerializer(Empresa.objects.all(), many=True)
+        ser_return = {
+            'listaEmpresa': empresas.data
+        }
+        return JSONResponse(ser_return, status=200)
+    return HttpResponseBadRequest()

--- a/lanternaverde_web/empresa.py
+++ b/lanternaverde_web/empresa.py
@@ -5,7 +5,7 @@ from .utils.jsonresponse import JSONResponse
 from django.http import HttpResponse, HttpResponseBadRequest
 
 
-def detalhar_empresa(request):
+def detalhar_empresa_public(request):
     """
     Método para detalhar uma empresa sem necessariamente estar logado (visão do consumidor)
     """
@@ -23,13 +23,39 @@ def detalhar_empresa(request):
     return HttpResponseBadRequest()
 
 
+def detalhar_empresa(request):
+    """
+    Método para detalhar uma empresa sem necessariamente estar logado (visão do consumidor)
+    """
+    if request.method == 'GET':
+        data = request.GET
+        try:
+            empresa = Empresa.objects.get(pk=data.get('companyid'))
+        except Exception as error:
+            return HttpResponse(error, status=404)
+        ser_empresa = EmpresaSerializer(empresa).data
+        ser_return = {
+            "Empresa": ser_empresa
+        }
+        return JSONResponse(ser_return, status=200)
+    return HttpResponseBadRequest()
+
+
 def listar_empresas(request):
     if request.method == 'GET':
         #pylint: disable=E1101
-        if hasattr(request.user, 'administrador'):
-            empresas = EmpresaSerializer(Empresa.objects.all(), many=True)
-        else:
-            empresas = EmpresaPublicSerializer(Empresa.objects.all(), many=True)
+        empresas = EmpresaSerializer(Empresa.objects.all(), many=True)
+        ser_return = {
+            'listaEmpresa': empresas.data
+        }
+        return JSONResponse(ser_return, status=200)
+    return HttpResponseBadRequest()
+
+
+def listar_empresas_public(request):
+    if request.method == 'GET':
+        # pylint: disable=E1101
+        empresas = EmpresaPublicSerializer(Empresa.objects.all(), many=True)
         ser_return = {
             'listaEmpresa': empresas.data
         }

--- a/lanternaverde_web/empresa.py
+++ b/lanternaverde_web/empresa.py
@@ -25,7 +25,7 @@ def detalhar_empresa_public(request):
 
 def detalhar_empresa(request):
     """
-    Método para detalhar uma empresa sem necessariamente estar logado (visão do consumidor)
+    Método para detalhar uma empresa com todas os dados
     """
     if request.method == 'GET':
         data = request.GET
@@ -42,6 +42,9 @@ def detalhar_empresa(request):
 
 
 def listar_empresas(request):
+    """
+    Lista as empresas com todos os dados
+    """
     if request.method == 'GET':
         #pylint: disable=E1101
         empresas = EmpresaSerializer(Empresa.objects.all(), many=True)
@@ -53,6 +56,9 @@ def listar_empresas(request):
 
 
 def listar_empresas_public(request):
+    """
+    Lista as empresas com dados limitados (visão de consumidor)
+    """
     if request.method == 'GET':
         # pylint: disable=E1101
         empresas = EmpresaPublicSerializer(Empresa.objects.all(), many=True)

--- a/lanternaverde_web/serializers.py
+++ b/lanternaverde_web/serializers.py
@@ -113,4 +113,4 @@ class EmpresaPublicSerializer(serializers.ModelSerializer):
     """
     class Meta:
         model = Empresa
-        exclude = ['package', 'stateRegistration', 'phoneNumber', 'user']
+        fields = ['id', 'tradeName', 'corporateName', 'tipo', 'cnpj', 'score']

--- a/lanternaverde_web/serializers.py
+++ b/lanternaverde_web/serializers.py
@@ -105,3 +105,12 @@ class NotificacoesAdmSerializer(serializers.ModelSerializer):
         """Relatorio metadata"""
         model = NotificacaoAdm
         fields = '__all__'
+
+
+class EmpresaPublicSerializer(serializers.ModelSerializer):
+    """
+    Public Serializer for Empresa (public view)
+    """
+    class Meta:
+        model = Empresa
+        exclude = ['package', 'stateRegistration', 'phoneNumber', 'user']

--- a/lanternaverde_web/urls.py
+++ b/lanternaverde_web/urls.py
@@ -54,6 +54,7 @@ urlpatterns = [
     path('notificacoes', views.listar_notificacoesAdm, name='listar_norificacoes'),
     path('notificacoes/read', views.notificacao_lida, name='notificacao_lida'),
 
-
+    path('public/empresa', views.listar_empresas_public, name='listar_empresas'),
+    path('public/empresa/detail', views.detalhar_empresa_public, name='detalhar_empresa'),
 
 ]

--- a/lanternaverde_web/urls.py
+++ b/lanternaverde_web/urls.py
@@ -45,12 +45,15 @@ urlpatterns = [
     #path('empresa/<str:id>', views.get_empresa, name='get_empresa'),
     path('empresa/report', views.compilar_relatorio_geral_empresa, name='compilar_relatorio_geral_empresa'),
     path('empresa', views.listar_empresas, name='listar_empresas'),
+    path('empresa/detail', views.detalhar_empresa, name='detalhar_empresa'),
 
     path('relatorio', views.get_relatorios, name='get_relatorios'),
     path('relatorio/comment', views.comment_relatorio, name='comment_relatorio'),
     path('relatorio/empresa', views.get_relatorios_por_empresa, name='get_relatorios_por_empresa'),
 
     path('notificacoes', views.listar_notificacoesAdm, name='listar_norificacoes'),
-    path('notificacoes/read', views.notificacao_lida, name='notificacao_lida')
+    path('notificacoes/read', views.notificacao_lida, name='notificacao_lida'),
+
+
 
 ]

--- a/lanternaverde_web/views.py
+++ b/lanternaverde_web/views.py
@@ -11,6 +11,7 @@ import lanternaverde_web.solicitacaoAnalise as solAnalise
 import lanternaverde_web.avaliacaoAnalista as avalAnalista
 import lanternaverde_web.relatorio as relatorio
 import lanternaverde_web.notificacaoAdm as notificacaoAdm
+import lanternaverde_web.empresa as empresa
 
 from django.contrib.auth.hashers import check_password
 
@@ -461,29 +462,9 @@ def get_info_analise_empresa(request, pk):
     return HttpResponseBadRequest()
 
 @login_required
-@administrador_required
 def listar_empresas(request):
-    if request.method == 'GET':
-        #pylint: disable=E1101
-        empresas = EmpresaSerializer(Empresa.objects.all(), many=True)
-        ser_return = {
-            'listaEmpresa': empresas.data
-        }
-        return JSONResponse(ser_return, status=200)
-    return HttpResponseBadRequest()
+    return empresa.listar_empresas(request)
 
-"""
-def get_empresa(request, id):
-    if request.method == 'GET':
-        empresas = EmpresaSerializer(
-            Empresa.objects.get(id=id)
-        )
-        ser_return = {
-            'Empresa': empresas.data
-        }
-        return JSONResponse(ser_return, status=200)
-    return HttpResponseBadRequest()
-"""
 
 def get_ranking(request):
     if request.method == 'GET':
@@ -610,3 +591,8 @@ def listar_notificacoesAdm(request):
 @administrador_required
 def notificacao_lida(request):
     return notificacaoAdm.notificacao_lida(request)
+
+
+@csrf_exempt
+def detalhar_empresa(request):
+    return empresa.detalhar_empresa(request)

--- a/lanternaverde_web/views.py
+++ b/lanternaverde_web/views.py
@@ -462,9 +462,26 @@ def get_info_analise_empresa(request, pk):
     return HttpResponseBadRequest()
 
 @login_required
+@administrador_required
 def listar_empresas(request):
     return empresa.listar_empresas(request)
 
+
+def listar_empresas_public(request):
+    return empresa.listar_empresas_public(request)
+
+"""
+def get_empresa(request, id):
+    if request.method == 'GET':
+        empresas = EmpresaSerializer(
+            Empresa.objects.get(id=id)
+        )
+        ser_return = {
+            'Empresa': empresas.data
+        }
+        return JSONResponse(ser_return, status=200)
+    return HttpResponseBadRequest()
+"""
 
 def get_ranking(request):
     if request.method == 'GET':
@@ -594,5 +611,12 @@ def notificacao_lida(request):
 
 
 @csrf_exempt
+def detalhar_empresa_public(request):
+    return empresa.detalhar_empresa_public(request)
+
+
+@csrf_exempt
+@login_required(login_url='/')
+@administrador_required
 def detalhar_empresa(request):
     return empresa.detalhar_empresa(request)

--- a/lanternaverde_web/views.py
+++ b/lanternaverde_web/views.py
@@ -610,12 +610,10 @@ def notificacao_lida(request):
     return notificacaoAdm.notificacao_lida(request)
 
 
-@csrf_exempt
 def detalhar_empresa_public(request):
     return empresa.detalhar_empresa_public(request)
 
 
-@csrf_exempt
 @login_required(login_url='/')
 @administrador_required
 def detalhar_empresa(request):


### PR DESCRIPTION
<!-- Está criando uma Pull Request pela primeira vez? Deixe esse modelo guiar você -->

Nesta Pull Request é implementada a visão de consumidor sobre as empresas
<!-- Nesse campo faça um pequeno sumário das suas implementações e seja breve, deixe para detalhar nos campos mais específicos. -->

## Problema

Anteriormente tínhamos visões que permitiam apenas administradores ter uma lista das empresas, e só uma empresa ter acesso aos seus próprios dados. Porém um dos atores que futuramente virão a ser implementados é o consumidor, que pode visualizar certas informações a partir da tela inicial, que conta com a lista e o ranking das empresas

## Implementação

Para criar a visão do consumidor sobre as empresas, era necessário avaliar quais informações podem ser públicas, então foi criado um novo serializer que exclui algumas informações e é usada para serializar os dados quando um consumidor não logado faz a requisição usando as rotas `public`

## Como Testar

- [Pacote postman com alguns testes implementados](https://www.getpostman.com/collections/a687e76494bf4d765a57)
- `public/empresa`: lista as empresas com informações limitadas para serem visualizadas pelos consumidores
- `empresa`: lista as empresas com todos os dados
- `public/empresa/detail?companyid=x`: detalha uma empresa com dados limitados
- `empresa/detail?companyid=x`: detalha uma empresa com todas as informações
 `x`: id da empresa


## Objetivos

This PR resolves #39 
