### PR TITLE
[Feature] Visual amigável para a Tela de Questionário do Analista

### DIFF
--- a/Frontend/public/images/v.svg
+++ b/Frontend/public/images/v.svg
@@ -1,0 +1,4 @@
+<svg width="83" height="64" viewBox="0 0 83 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="47.9793" height="19.9914" rx="9.99569" transform="matrix(0.706802 0.707411 -0.706802 0.707411 14.2126 15)" fill="white"/>
+<rect width="68.8954" height="19.9914" rx="9.99569" transform="matrix(0.706802 -0.707411 0.706802 0.707411 20.0655 48.7374)" fill="white"/>
+</svg>

--- a/Frontend/public/images/x.svg
+++ b/Frontend/public/images/x.svg
@@ -1,0 +1,4 @@
+<svg width="63" height="62" viewBox="0 0 63 62" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="65.9716" height="19.9914" rx="9.99569" transform="matrix(0.706802 -0.707411 0.706802 0.707411 0.97937 46.669)" fill="white"/>
+<rect width="65.9716" height="19.9914" rx="9.99569" transform="matrix(0.706802 0.707411 -0.706802 0.707411 15.1094 0)" fill="white"/>
+</svg>

--- a/Frontend/src/components/Analyst/analysis/Analysis.css
+++ b/Frontend/src/components/Analyst/analysis/Analysis.css
@@ -59,5 +59,3 @@
   width: 75px;
   height: 50px;
 }
-
-

--- a/Frontend/src/components/Analyst/analysis/Analysis.css
+++ b/Frontend/src/components/Analyst/analysis/Analysis.css
@@ -1,17 +1,4 @@
-.listQuestoes{
-    max-height: 100%;
-    background-color: rgb(44, 196, 163);
-    border-radius: 10px;
-    color:  rgb(56, 57, 58);
-    margin-top: 20xp;
-    text-align: center;
-    max-width: 100%;
-    padding: 8px 8px 8px 8px;
-    margin-top: 20px;
-    display: flex;
-    justify-content: space-between;
-    text-align: center;
-}
+
 
 .question-and-answer {
   
@@ -61,32 +48,7 @@
   margin-right: 10px;
 }
 
-.comentArea {
-  width: 100%;
-  height: 40vh;
-  border: 3px solid;
-  border-radius: 10px;
-  border-color: rgb(56, 57, 58);
-  resize: none;
-}
 
-.sourceArea {
-  width: 100%;
-  height: 10vh;
-  border: 3px solid;
-  border-radius: 10px;
-  border-color: rgb(56, 57, 58);
-  resize: none;
-}
-
-.justificationArea {
-  width: 100%;
-  height: 20vh;
-  border: 3px solid;
-  border-radius: 10px;
-  border-color: rgb(56, 57, 58);
-  resize: none;
-}
 
  .btns{
   margin-top: 20px;
@@ -99,62 +61,3 @@
 }
 
 
-.switch {
-    position: relative;
-    display: inline-block;
-    width: 60px;
-    height: 34px;
-  }
-  
-  .switch input { 
-    opacity: 0;
-    width: 0;
-    height: 0;
-  }
-  
-  .slider {
-    position: absolute;
-    cursor: pointer;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background-color: #ccc;
-    -webkit-transition: .4s;
-    transition: .4s;
-  }
-  
-  .slider:before {
-    position: absolute;
-    content: "";
-    height: 26px;
-    width: 26px;
-    left: 4px;
-    bottom: 4px;
-    background-color: white;
-    -webkit-transition: .4s;
-    transition: .4s;
-  }
-  
-  input:checked + .slider {
-    background-color: #21f33d;
-  }
-  
-  input:focus + .slider {
-    box-shadow: 0 0 1px #21f33d;
-  }
-  
-  input:checked + .slider:before {
-    -webkit-transform: translateX(26px);
-    -ms-transform: translateX(26px);
-    transform: translateX(26px);
-  }
-  
-  /* Rounded sliders */
-  .slider.round {
-    border-radius: 34px;
-  }
-  
-  .slider.round:before {
-    border-radius: 50%;
-  }

--- a/Frontend/src/components/Analyst/analysis/AnalysisDetails.js
+++ b/Frontend/src/components/Analyst/analysis/AnalysisDetails.js
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import './Analysis.css'
 import Questions from './Questions';
 import QuestionsFinished from './QuestionsFinished';
@@ -19,6 +19,10 @@ const Analysis = ({ analise }) => {
     const [analysis,setAnalysis] = useState("placeholder");
     const [dimensions,setDimensions] = useState({});
 
+    useEffect(() => {
+        analysisDetail()
+    },[])
+
     async function analysisDetail() {
         let response = await axios.get(
           url,
@@ -32,9 +36,9 @@ const Analysis = ({ analise }) => {
         
       }
 
-      if (analysis === "placeholder"){
-        analysisDetail()
-      }
+      // if (analysis === "placeholder"){
+      //   analysisDetail()
+      // }
 
 
 

--- a/Frontend/src/components/Analyst/analysis/Question.css
+++ b/Frontend/src/components/Analyst/analysis/Question.css
@@ -13,11 +13,11 @@
 .full-question-area{
 
     max-height: 100%;
-    background-color: rgb(224, 224, 224);
-    border-radius: 10px;
+    /* background-color: #F0F0F0; */
+    border-radius: 20px;
     color:  rgb(0, 0, 0);
     text-align: center;
-    width: 60vw;
+    width: 90%;
     /* padding: 8px 8px 8px 8px; */
 
     display: flex;
@@ -43,17 +43,18 @@
 
 } */
 .negative-btn {
-    background-color: red;
+    background-color: #E74C3C;
     color: white;
     font-size: xx-large;
     height: 12vh;
     width: 50%;
-    border-top-left-radius: 10px;
-    border-bottom-left-radius: 10px;
+    border-radius: 20px;
     border-width: 0px;
     text-align: left;
     position: absolute;
+    padding: 15px 15px 15px 15px;
     /* left: 0px; */
+    font-weight:bold;
 }
 
 /* .positive-container{
@@ -65,18 +66,19 @@
 } */
 .positive-btn {
 
-    background-color: greenyellow;
+    background-color: #1BB55C;
     color: white;
     font-size: xx-large;
     height: 12vh;
     width: 50%;
-    border-top-right-radius: 10px;
-    border-bottom-right-radius: 10px;
+    border-radius: 20px;
     border-width: 0px;
     text-align: right;
     z-index: 0;
     position: absolute;
+    padding: 15px 15px 15px 15px;
     right: 0;
+    font-weight:bold;
     
     /* right: 0px; */
 
@@ -85,7 +87,7 @@
 /* containers */
 
 .source-container{
-    background-color: rgb(224, 224, 224);
+    background-color: #F0F0F0;
     width: 100%;
     /* border: 3px solid; */
     /* border-radius: 10px; */
@@ -101,7 +103,7 @@
 } */
 
 .justification-container{
-    background-color: rgb(224, 224, 224);
+    background-color: #F0F0F0;
     width: 100%;
     /* border: 3px solid; */
     /* border-radius: 10px; */
@@ -128,17 +130,18 @@
     text-align: center;
 }
 .questionArea {
-    overflow-y: scroll;
+    /* overflow-y: scroll; */
     height: 12vh;
-    background-color: rgb(224, 224, 224);
+    background-color: #F0F0F0;
     color:  rgb(0, 0, 0);
     text-align: center;
     width: 100%;
     padding: 8px 8px 8px 8px;
     /* border-style: solid;
     border-color: black; */
-    border-radius: 10px;
+    border-radius: 20px;
     /* position: absolute; */
+    position: relative;
     
 }
 
@@ -171,5 +174,37 @@
     border-color: rgb(56, 57, 58);
     
     resize: none;
+}
+
+
+/* animation */
+
+.classname {
+
+    overflow-y: scroll;
+    height: 12vh;
+    background-color: #F0F0F0;
+    color:  rgb(0, 0, 0);
+    text-align: center;
+    width: 100%;
+    padding: 8px 8px 8px 8px;
+    /* border-style: solid;
+    border-color: black; */
+    border-radius: 20px;
+    /* position: absolute; */
+    position: relative;
+    
+    animation-name: negative;
+    animation-duration: 2s;
+    
+
+}
+
+@keyframes negative {
+    100% {transform: translate(6.25%, 0%);}
+}
+
+@keyframes positive {
+    100% {transform: translate(-6.25%, 0%);}
 }
 

--- a/Frontend/src/components/Analyst/analysis/Question.css
+++ b/Frontend/src/components/Analyst/analysis/Question.css
@@ -1,55 +1,92 @@
 .question-container{
+    
     display: flex;
-    flex-direction: column;
-    justify-content: center;
+    flex-direction: row;
+    justify-content: space-between;
     text-align: center;
-    align-items: center;
+    margin-top: 20px;
+    margin-left: 10%;
+    margin-right: 10%;
+    position:relative;
 }
 
 .full-question-area{
+
     max-height: 100%;
     background-color: rgb(224, 224, 224);
     border-radius: 10px;
     color:  rgb(0, 0, 0);
-    margin-top: 20xp;
     text-align: center;
-    width: 80vw;
+    width: 60vw;
     /* padding: 8px 8px 8px 8px; */
-    margin-top: 20px;
+
     display: flex;
+    flex-direction: column;
     justify-content: space-between;
     text-align: center;
+    align-items: center;
+    margin-right: auto;
+    margin-left: auto;
+    /* position: absolute; */
+    z-index: 1;
+    
 }
 
 /* buttons */
 
+/* .negative-container{
+
+    margin-right: 0;
+    margin-left:auto;
+    z-index: 0;
+    position: absolute;
+
+} */
 .negative-btn {
     background-color: red;
     color: white;
     font-size: xx-large;
-    height: 100;
-    width: 25%;
+    height: 12vh;
+    width: 50%;
     border-top-left-radius: 10px;
     border-bottom-left-radius: 10px;
     border-width: 0px;
+    text-align: left;
+    position: absolute;
+    /* left: 0px; */
 }
 
+/* .positive-container{
+
+    margin-right: 0;
+    z-index: 0;
+    position: absolute;
+
+} */
 .positive-btn {
+
     background-color: greenyellow;
     color: white;
     font-size: xx-large;
-    height: 100;
-    width: 25%;
+    height: 12vh;
+    width: 50%;
     border-top-right-radius: 10px;
     border-bottom-right-radius: 10px;
     border-width: 0px;
+    text-align: right;
+    z-index: 0;
+    position: absolute;
+    right: 0;
+    
+    /* right: 0px; */
+
 }
 
 /* containers */
 
 .source-container{
     background-color: rgb(224, 224, 224);
-    width: 52%;
+    width: 100%;
     /* border: 3px solid; */
     /* border-radius: 10px; */
     /* border-color: rgb(56, 57, 58);
@@ -57,9 +94,15 @@
     
 }
 
+/* .source-container .titulo {
+    text-align: left;
+    margin-left: 50px;
+    
+} */
+
 .justification-container{
     background-color: rgb(224, 224, 224);
-    width: 52%;
+    width: 100%;
     /* border: 3px solid; */
     /* border-radius: 10px; */
     /* border-color: rgb(56, 57, 58);
@@ -67,6 +110,13 @@
     border-bottom-left-radius: 10px;
     border-bottom-right-radius: 10px;
     
+}
+
+.text-and-buttons-container {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    text-align: center;
 }
 
 /* areas */
@@ -78,16 +128,18 @@
     text-align: center;
 }
 .questionArea {
-    max-height: 100%;
+    overflow-y: scroll;
+    height: 12vh;
     background-color: rgb(224, 224, 224);
     color:  rgb(0, 0, 0);
     text-align: center;
-    max-width: 100%;
+    width: 100%;
     padding: 8px 8px 8px 8px;
     /* border-style: solid;
     border-color: black; */
-    border-top-left-radius: 10px;
-    border-top-right-radius: 10px;
+    border-radius: 10px;
+    /* position: absolute; */
+    
 }
 
 .comentArea {
@@ -111,75 +163,13 @@
 }
   
 .justificationArea {
+    /* margin-top: 12vh; */
     width: 90%;
     height: 20vh;
     border: 3px solid;
     border-radius: 10px;
     border-color: rgb(56, 57, 58);
-
+    
     resize: none;
-}
-
-
-/* Switch */
-
-.switch {
-    position: relative;
-    display: inline-block;
-    width: 60px;
-    height: 34px;
-}
-  
-.switch input { 
-    opacity: 0;
-    width: 0;
-    height: 0;
-}
-  
-.slider {
-    position: absolute;
-    cursor: pointer;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background-color: #ccc;
-    -webkit-transition: .4s;
-    transition: .4s;
-}
-
-.slider:before {
-    position: absolute;
-    content: "";
-    height: 26px;
-    width: 26px;
-    left: 4px;
-    bottom: 4px;
-    background-color: white;
-    -webkit-transition: .4s;
-    transition: .4s;
-}
-  
-input:checked + .slider {
-    background-color: #21f33d;
-}
-  
-input:focus + .slider {
-    box-shadow: 0 0 1px #21f33d;
-}
-  
-input:checked + .slider:before {
-    -webkit-transform: translateX(26px);
-    -ms-transform: translateX(26px);
-    transform: translateX(26px);
-}
-  
-/* Rounded sliders */
-.slider.round {
-    border-radius: 34px;
-}
-  
-.slider.round:before {
-    border-radius: 50%;
 }
 

--- a/Frontend/src/components/Analyst/analysis/Question.css
+++ b/Frontend/src/components/Analyst/analysis/Question.css
@@ -1,3 +1,5 @@
+
+
 .question-container{
     
     display: flex;
@@ -130,11 +132,6 @@
     text-align: center;
 }
 
-.justi-src-container {
-    width: 100%;
-    overflow: hidden;
-}
-
 /* areas */
 
 .alig-areas{
@@ -162,10 +159,6 @@
     align-items: center;
     
     
-}
-
-.questionArea:hover {
-    cursor:pointer;
 }
 
 .comentArea {

--- a/Frontend/src/components/Analyst/analysis/Question.css
+++ b/Frontend/src/components/Analyst/analysis/Question.css
@@ -1,3 +1,5 @@
+
+
 .question-container{
     
     display: flex;
@@ -8,16 +10,18 @@
     margin-left: 10%;
     margin-right: 10%;
     position:relative;
+    font-weight: bold;
+    font-size: large;
 }
 
 .full-question-area{
-
+    --quest-width: 90%;
     max-height: 100%;
     /* background-color: #F0F0F0; */
     border-radius: 20px;
     color:  rgb(0, 0, 0);
     text-align: center;
-    width: 90%;
+    width: var(--quest-width);
     /* padding: 8px 8px 8px 8px; */
 
     display: flex;
@@ -46,7 +50,7 @@
     background-color: #E74C3C;
     color: white;
     font-size: xx-large;
-    height: 12vh;
+    height: 15vh;
     width: 50%;
     border-radius: 20px;
     border-width: 0px;
@@ -69,7 +73,7 @@
     background-color: #1BB55C;
     color: white;
     font-size: xx-large;
-    height: 12vh;
+    height: 15vh;
     width: 50%;
     border-radius: 20px;
     border-width: 0px;
@@ -93,14 +97,16 @@
     /* border-radius: 10px; */
     /* border-color: rgb(56, 57, 58);
     margin: 0px; */
+    border-bottom-left-radius: 20px;
+    border-bottom-right-radius: 20px;
     
 }
 
-/* .source-container .titulo {
+.source-container .source-tittle {
     text-align: left;
-    margin-left: 50px;
+    margin-left: 5%;
     
-} */
+}
 
 .justification-container{
     background-color: #F0F0F0;
@@ -109,9 +115,14 @@
     /* border-radius: 10px; */
     /* border-color: rgb(56, 57, 58);
     margin: 0px; */
-    border-bottom-left-radius: 10px;
-    border-bottom-right-radius: 10px;
+    /* border-bottom-left-radius: 10px;
+    border-bottom-right-radius: 10px; */
     
+}
+
+.justification-container .just-tittle{
+    text-align: left;
+    margin-left: 5%;
 }
 
 .text-and-buttons-container {
@@ -131,7 +142,7 @@
 }
 .questionArea {
     /* overflow-y: scroll; */
-    height: 12vh;
+    height: 15vh;
     background-color: #F0F0F0;
     color:  rgb(0, 0, 0);
     text-align: center;
@@ -142,6 +153,11 @@
     border-radius: 20px;
     /* position: absolute; */
     position: relative;
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    
     
 }
 
@@ -200,11 +216,31 @@
 
 }
 
-@keyframes negative {
+@keyframes negative-neutral {
     100% {transform: translate(6.25%, 0%);}
 }
 
-@keyframes positive {
+@keyframes positive-neutral {
     100% {transform: translate(-6.25%, 0%);}
 }
 
+
+@keyframes negative {
+    from {
+        transform: translate(-6.25%,0%);
+      }
+    
+      to {
+        transform: translate(6.25%,0%);
+      }
+}
+
+@keyframes positive {
+    from {
+        transform: translate(6.25%,0%);
+      }
+    
+      to {
+        transform: translate(-6.25%,0%);
+      }
+}

--- a/Frontend/src/components/Analyst/analysis/Question.css
+++ b/Frontend/src/components/Analyst/analysis/Question.css
@@ -1,5 +1,3 @@
-
-
 .question-container{
     
     display: flex;
@@ -132,6 +130,11 @@
     text-align: center;
 }
 
+.justi-src-container {
+    width: 100%;
+    overflow: hidden;
+}
+
 /* areas */
 
 .alig-areas{
@@ -159,6 +162,10 @@
     align-items: center;
     
     
+}
+
+.questionArea:hover {
+    cursor:pointer;
 }
 
 .comentArea {

--- a/Frontend/src/components/Analyst/analysis/Question.css
+++ b/Frontend/src/components/Analyst/analysis/Question.css
@@ -1,20 +1,94 @@
-.listQuestoes{
+.question-container{
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    text-align: center;
+    align-items: center;
+}
+
+.full-question-area{
     max-height: 100%;
-    background-color: rgb(44, 196, 163);
+    background-color: rgb(224, 224, 224);
     border-radius: 10px;
-    color:  rgb(56, 57, 58);
+    color:  rgb(0, 0, 0);
     margin-top: 20xp;
     text-align: center;
-    max-width: 100%;
-    padding: 8px 8px 8px 8px;
+    width: 80vw;
+    /* padding: 8px 8px 8px 8px; */
     margin-top: 20px;
     display: flex;
     justify-content: space-between;
     text-align: center;
 }
 
+/* buttons */
+
+.negative-btn {
+    background-color: red;
+    color: white;
+    font-size: xx-large;
+    height: 100;
+    width: 25%;
+    border-top-left-radius: 10px;
+    border-bottom-left-radius: 10px;
+    border-width: 0px;
+}
+
+.positive-btn {
+    background-color: greenyellow;
+    color: white;
+    font-size: xx-large;
+    height: 100;
+    width: 25%;
+    border-top-right-radius: 10px;
+    border-bottom-right-radius: 10px;
+    border-width: 0px;
+}
+
+/* containers */
+
+.source-container{
+    background-color: rgb(224, 224, 224);
+    width: 52%;
+    /* border: 3px solid; */
+    /* border-radius: 10px; */
+    /* border-color: rgb(56, 57, 58);
+    margin: 0px; */
+    
+}
+
+.justification-container{
+    background-color: rgb(224, 224, 224);
+    width: 52%;
+    /* border: 3px solid; */
+    /* border-radius: 10px; */
+    /* border-color: rgb(56, 57, 58);
+    margin: 0px; */
+    border-bottom-left-radius: 10px;
+    border-bottom-right-radius: 10px;
+    
+}
 
 /* areas */
+
+.alig-areas{
+    display: flex;
+    flex-direction: column;
+    justify-content: space-evenly;
+    text-align: center;
+}
+.questionArea {
+    max-height: 100%;
+    background-color: rgb(224, 224, 224);
+    color:  rgb(0, 0, 0);
+    text-align: center;
+    max-width: 100%;
+    padding: 8px 8px 8px 8px;
+    /* border-style: solid;
+    border-color: black; */
+    border-top-left-radius: 10px;
+    border-top-right-radius: 10px;
+}
 
 .comentArea {
     width: 100%;
@@ -23,23 +97,26 @@
     border-radius: 10px;
     border-color: rgb(56, 57, 58);
     resize: none;
+    
 }
-  
+
 .sourceArea {
-    width: 100%;
-    height: 10vh;
+    width: 90%;
+    height: 5vh;
     border: 3px solid;
     border-radius: 10px;
     border-color: rgb(56, 57, 58);
     resize: none;
+    
 }
   
 .justificationArea {
-    width: 100%;
+    width: 90%;
     height: 20vh;
     border: 3px solid;
     border-radius: 10px;
     border-color: rgb(56, 57, 58);
+
     resize: none;
 }
 

--- a/Frontend/src/components/Analyst/analysis/Question.css
+++ b/Frontend/src/components/Analyst/analysis/Question.css
@@ -1,0 +1,108 @@
+.listQuestoes{
+    max-height: 100%;
+    background-color: rgb(44, 196, 163);
+    border-radius: 10px;
+    color:  rgb(56, 57, 58);
+    margin-top: 20xp;
+    text-align: center;
+    max-width: 100%;
+    padding: 8px 8px 8px 8px;
+    margin-top: 20px;
+    display: flex;
+    justify-content: space-between;
+    text-align: center;
+}
+
+
+/* areas */
+
+.comentArea {
+    width: 100%;
+    height: 40vh;
+    border: 3px solid;
+    border-radius: 10px;
+    border-color: rgb(56, 57, 58);
+    resize: none;
+}
+  
+.sourceArea {
+    width: 100%;
+    height: 10vh;
+    border: 3px solid;
+    border-radius: 10px;
+    border-color: rgb(56, 57, 58);
+    resize: none;
+}
+  
+.justificationArea {
+    width: 100%;
+    height: 20vh;
+    border: 3px solid;
+    border-radius: 10px;
+    border-color: rgb(56, 57, 58);
+    resize: none;
+}
+
+
+/* Switch */
+
+.switch {
+    position: relative;
+    display: inline-block;
+    width: 60px;
+    height: 34px;
+}
+  
+.switch input { 
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+  
+.slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #ccc;
+    -webkit-transition: .4s;
+    transition: .4s;
+}
+
+.slider:before {
+    position: absolute;
+    content: "";
+    height: 26px;
+    width: 26px;
+    left: 4px;
+    bottom: 4px;
+    background-color: white;
+    -webkit-transition: .4s;
+    transition: .4s;
+}
+  
+input:checked + .slider {
+    background-color: #21f33d;
+}
+  
+input:focus + .slider {
+    box-shadow: 0 0 1px #21f33d;
+}
+  
+input:checked + .slider:before {
+    -webkit-transform: translateX(26px);
+    -ms-transform: translateX(26px);
+    transform: translateX(26px);
+}
+  
+/* Rounded sliders */
+.slider.round {
+    border-radius: 34px;
+}
+  
+.slider.round:before {
+    border-radius: 50%;
+}
+

--- a/Frontend/src/components/Analyst/analysis/Questions.js
+++ b/Frontend/src/components/Analyst/analysis/Questions.js
@@ -1,5 +1,5 @@
 import React, {useState} from 'react';
-import './Analysis.css'
+import './Question.css'
 
 const Questions = ({ questao, analysis, setDimensions, handleCheckBoxClick, handleSourceChange, handleJustificationChange }) => {
     

--- a/Frontend/src/components/Analyst/analysis/Questions.js
+++ b/Frontend/src/components/Analyst/analysis/Questions.js
@@ -1,9 +1,14 @@
-import React, {useEffect} from 'react';
-import './Question.css'
-
+import React, {useEffect, useState} from 'react';
+import './Question.css';
+import Collapse from 'react-bootstrap/Collapse';
 const Questions = ({ questao, analysis, setDimensions, handleCheckBoxClick, handleSourceChange, handleJustificationChange }) => {
     
 
+
+
+
+
+    const [active, setActive] = useState(false);
     useEffect(() => {
         // setQuest(questao)
         initAnswer()
@@ -23,12 +28,14 @@ const Questions = ({ questao, analysis, setDimensions, handleCheckBoxClick, hand
         var box = document.getElementById('question'+questao.id)
         if (questao.answer){
             box.style.animation = "negative 0.125s linear forwards";
-            questao.answer = !questao.answer
+            // questao.answer = !questao.answer
+            
         }
         else{
             box.style.animation = "positive 0.125s linear forwards";
-            questao.answer = !questao.answer
+            // questao.answer = !questao.answer
         }
+        handleCheckBoxClick(questao)
 
     }
       
@@ -42,10 +49,14 @@ const Questions = ({ questao, analysis, setDimensions, handleCheckBoxClick, hand
         handleJustificationChange(justificationValue,questao)
     }
 
-
+    function questionClickHandler() {
+        setActive(!active)
+    }
 
     // document.onload = initAnswer();
     return <>
+            <script src="https://unpkg.com/react/umd/react.production.min.js"></script>
+            <script src="https://unpkg.com/react-collapse/build/react-collapse.min.js"></script>
             <div className='question-container'>
 
                 {/* <div className='negative-container'> */}
@@ -58,22 +69,30 @@ const Questions = ({ questao, analysis, setDimensions, handleCheckBoxClick, hand
                 <div className='full-question-area'>
                     {/* <div className='question-and-awnser'> */}
                     
-                    
-                    {/* <div className='alig-areas'> */}
+                    {/* <UnmountClosed isOpened={active} initialStyle={{height: 0, overflow: 'hidden'}}>
+                        alooooooooooooooooooooooooooooooooooo
+                    </UnmountClosed> */}
 
-                        <div className='questionArea' id={'question'+questao.id}>
+
+                    {/* <div className='alig-areas'> */}
+                        <div className='questionArea' id={'question'+questao.id} onClick= {questionClickHandler}>
                             {questao.question.body} 
                         </div>
 
-                        <div className='justification-container' >
-                            <div className='just-tittle'>Justificativa:</div>
-                            <textarea  className='justificationArea' id = {'questionJustification'+questao.id} onChange={justificationAreaChange}>{questao.justification}</textarea>  <br></br>
-                        </div>
-                        
-                        <div className='source-container'>
-                            <div className='source-tittle'>Fonte:</div>
-                            <textarea  className='sourceArea' id = {'questionSource'+questao.id} onChange={sourceAreaChange}>{questao.source}</textarea> <br></br>
-                        </div>
+                    <Collapse in={active}>
+                        <div className='justi-src-container'>
+                            <div className='justification-container' >
+                                <div className='just-tittle'>Justificativa:</div>
+                                <textarea  className='justificationArea' id = {'questionJustification'+questao.id} onChange={justificationAreaChange}>{questao.justification}</textarea>  <br></br>
+                            </div>
+                            
+                            <div className='source-container'>
+                                <div className='source-tittle'>Fonte:</div>
+                                <textarea  className='sourceArea' id = {'questionSource'+questao.id} onChange={sourceAreaChange}>{questao.source}</textarea> <br></br>
+                            </div>
+                        </div> 
+                    </Collapse>
+
 
 
 

--- a/Frontend/src/components/Analyst/analysis/Questions.js
+++ b/Frontend/src/components/Analyst/analysis/Questions.js
@@ -39,18 +39,36 @@ const Questions = ({ questao, analysis, setDimensions, handleCheckBoxClick, hand
     return <>
             <div className='question-container'>
 
-            
+                {/* <div className='negative-container'> */}
+                    <button className='negative-btn'>X</button>
+                {/* </div> */}
+                
+
                 <div className='full-question-area'>
                     {/* <div className='question-and-awnser'> */}
-                    <button className='negative-btn'>X</button>
+                    
                     
                     {/* <div className='alig-areas'> */}
+
                         <div className='questionArea'>
-                            {questao.question.body} 
-                            </div>
+                        {questao.question.body} 
+                        
+                        </div>
+                        
+                        <br></br>
+                        <div className='justification-container'>
+                            Justificativa:<br></br> <textarea  className='justificationArea' id = {'questionJustification'+questao.id} onChange={justificationAreaChange}>{questao.justification}</textarea>  <br></br>
+                        </div>
+                        
+                        <div className='source-container'>
+                            Fonte:<br></br> <textarea  className='sourceArea' id = {'questionSource'+questao.id} onChange={sourceAreaChange}>{questao.source}</textarea> <br></br>
+                        </div>
+
+
+
                     {/* </div> */}
 
-                    <button className='positive-btn'>V</button>      
+                       
                             {/* <label class="switch">
                                 <input type="checkbox" onClickCapture={() => handleCheckBoxClick(questao)} defaultChecked={questao.answer}></input>
                                 <span class="slider round">
@@ -58,14 +76,10 @@ const Questions = ({ questao, analysis, setDimensions, handleCheckBoxClick, hand
                             </label>  */}
                     {/* </div> */}
                 </div>
+                {/* <div className='positive-container'> */}
+                    <button className='positive-btn'>V</button>   
+                {/* </div> */}
 
-                <div className='source-container'>
-                    Fonte:<br></br> <textarea  className='sourceArea' id = {'questionSource'+questao.id} onChange={sourceAreaChange}>{questao.source}</textarea> <br></br>
-                </div>
-
-                <div className='justification-container'>
-                    Justificativa:<br></br> <textarea  className='justificationArea' id = {'questionJustification'+questao.id} onChange={justificationAreaChange}>{questao.justification}</textarea>  <br></br>
-                </div>
 
             </div>
             </>

--- a/Frontend/src/components/Analyst/analysis/Questions.js
+++ b/Frontend/src/components/Analyst/analysis/Questions.js
@@ -12,10 +12,10 @@ const Questions = ({ questao, analysis, setDimensions, handleCheckBoxClick, hand
     function initAnswer(){
         var box = document.getElementById('question'+questao.id)
         if (questao.answer){
-            box.style.animation = "positive 0.125s linear forwards";
+            box.style.animation = "positive-neutral 0.125s linear forwards";
         }
         else{
-            box.style.animation = "negative 0.125s linear forwards";
+            box.style.animation = "negative-neutral 0.125s linear forwards";
         }
     }
          
@@ -49,7 +49,9 @@ const Questions = ({ questao, analysis, setDimensions, handleCheckBoxClick, hand
             <div className='question-container'>
 
                 {/* <div className='negative-container'> */}
-                    <button className='negative-btn' onClick={answerHandler}>X</button>
+                    <button className='negative-btn' onClick={answerHandler}>
+                    <img src="../images/x.svg" alt="X"/>
+                    </button>
                 {/* </div> */}
                 
 
@@ -60,16 +62,17 @@ const Questions = ({ questao, analysis, setDimensions, handleCheckBoxClick, hand
                     {/* <div className='alig-areas'> */}
 
                         <div className='questionArea' id={'question'+questao.id}>
-                        {questao.question.body} 
-                        
+                            {questao.question.body} 
                         </div>
 
                         <div className='justification-container' >
-                            Justificativa:<br></br> <textarea  className='justificationArea' id = {'questionJustification'+questao.id} onChange={justificationAreaChange}>{questao.justification}</textarea>  <br></br>
+                            <div className='just-tittle'>Justificativa:</div>
+                            <textarea  className='justificationArea' id = {'questionJustification'+questao.id} onChange={justificationAreaChange}>{questao.justification}</textarea>  <br></br>
                         </div>
                         
                         <div className='source-container'>
-                            Fonte:<br></br> <textarea  className='sourceArea' id = {'questionSource'+questao.id} onChange={sourceAreaChange}>{questao.source}</textarea> <br></br>
+                            <div className='source-tittle'>Fonte:</div>
+                            <textarea  className='sourceArea' id = {'questionSource'+questao.id} onChange={sourceAreaChange}>{questao.source}</textarea> <br></br>
                         </div>
 
 
@@ -85,7 +88,9 @@ const Questions = ({ questao, analysis, setDimensions, handleCheckBoxClick, hand
                     {/* </div> */}
                 </div>
                 {/* <div className='positive-container'> */}
-                    <button className='positive-btn' onClick={answerHandler}>V</button>   
+                    <button className='positive-btn' onClick={answerHandler}>
+                        <img src="../images/v.svg" alt="V"/>
+                    </button>   
                 {/* </div> */}
 
 

--- a/Frontend/src/components/Analyst/analysis/Questions.js
+++ b/Frontend/src/components/Analyst/analysis/Questions.js
@@ -1,14 +1,9 @@
-import React, {useEffect, useState} from 'react';
-import './Question.css';
-import Collapse from 'react-bootstrap/Collapse';
+import React, {useEffect} from 'react';
+import './Question.css'
+
 const Questions = ({ questao, analysis, setDimensions, handleCheckBoxClick, handleSourceChange, handleJustificationChange }) => {
     
 
-
-
-
-
-    const [active, setActive] = useState(false);
     useEffect(() => {
         // setQuest(questao)
         initAnswer()
@@ -28,14 +23,12 @@ const Questions = ({ questao, analysis, setDimensions, handleCheckBoxClick, hand
         var box = document.getElementById('question'+questao.id)
         if (questao.answer){
             box.style.animation = "negative 0.125s linear forwards";
-            // questao.answer = !questao.answer
-            
+            questao.answer = !questao.answer
         }
         else{
             box.style.animation = "positive 0.125s linear forwards";
-            // questao.answer = !questao.answer
+            questao.answer = !questao.answer
         }
-        handleCheckBoxClick(questao)
 
     }
       
@@ -49,14 +42,10 @@ const Questions = ({ questao, analysis, setDimensions, handleCheckBoxClick, hand
         handleJustificationChange(justificationValue,questao)
     }
 
-    function questionClickHandler() {
-        setActive(!active)
-    }
+
 
     // document.onload = initAnswer();
     return <>
-            <script src="https://unpkg.com/react/umd/react.production.min.js"></script>
-            <script src="https://unpkg.com/react-collapse/build/react-collapse.min.js"></script>
             <div className='question-container'>
 
                 {/* <div className='negative-container'> */}
@@ -69,30 +58,22 @@ const Questions = ({ questao, analysis, setDimensions, handleCheckBoxClick, hand
                 <div className='full-question-area'>
                     {/* <div className='question-and-awnser'> */}
                     
-                    {/* <UnmountClosed isOpened={active} initialStyle={{height: 0, overflow: 'hidden'}}>
-                        alooooooooooooooooooooooooooooooooooo
-                    </UnmountClosed> */}
-
-
+                    
                     {/* <div className='alig-areas'> */}
-                        <div className='questionArea' id={'question'+questao.id} onClick= {questionClickHandler}>
+
+                        <div className='questionArea' id={'question'+questao.id}>
                             {questao.question.body} 
                         </div>
 
-                    <Collapse in={active}>
-                        <div className='justi-src-container'>
-                            <div className='justification-container' >
-                                <div className='just-tittle'>Justificativa:</div>
-                                <textarea  className='justificationArea' id = {'questionJustification'+questao.id} onChange={justificationAreaChange}>{questao.justification}</textarea>  <br></br>
-                            </div>
-                            
-                            <div className='source-container'>
-                                <div className='source-tittle'>Fonte:</div>
-                                <textarea  className='sourceArea' id = {'questionSource'+questao.id} onChange={sourceAreaChange}>{questao.source}</textarea> <br></br>
-                            </div>
-                        </div> 
-                    </Collapse>
-
+                        <div className='justification-container' >
+                            <div className='just-tittle'>Justificativa:</div>
+                            <textarea  className='justificationArea' id = {'questionJustification'+questao.id} onChange={justificationAreaChange}>{questao.justification}</textarea>  <br></br>
+                        </div>
+                        
+                        <div className='source-container'>
+                            <div className='source-tittle'>Fonte:</div>
+                            <textarea  className='sourceArea' id = {'questionSource'+questao.id} onChange={sourceAreaChange}>{questao.source}</textarea> <br></br>
+                        </div>
 
 
 

--- a/Frontend/src/components/Analyst/analysis/Questions.js
+++ b/Frontend/src/components/Analyst/analysis/Questions.js
@@ -1,32 +1,37 @@
-import React, {useState} from 'react';
+import React, {useEffect} from 'react';
 import './Question.css'
 
 const Questions = ({ questao, analysis, setDimensions, handleCheckBoxClick, handleSourceChange, handleJustificationChange }) => {
     
 
+    useEffect(() => {
+        // setQuest(questao)
+        initAnswer()
+    },[])
 
-    // const handleCheckBoxClick= () => {
-    //       questao.answer= !questao.answer;
+    function initAnswer(){
+        var box = document.getElementById('question'+questao.id)
+        if (questao.answer){
+            box.style.animation = "positive 0.125s linear forwards";
+        }
+        else{
+            box.style.animation = "negative 0.125s linear forwards";
+        }
+    }
+         
+    function answerHandler(){
+        var box = document.getElementById('question'+questao.id)
+        if (questao.answer){
+            box.style.animation = "negative 0.125s linear forwards";
+            questao.answer = !questao.answer
+        }
+        else{
+            box.style.animation = "positive 0.125s linear forwards";
+            questao.answer = !questao.answer
+        }
 
-    //       let valor = 1;
-    //       if(questao.answer === true){
-    //         valor = 1;
-    //       }
-    //       else{
-    //         valor = -1;
-    //       }
-
-    //       analysis.dimension_count[questao.question.dimension].checked += valor
-    //       const copy = analysis.dimension_count
-    //       setDimensions(copy)
-
-    //     //   console.log("resposta da questão ("+ questao.question.body + "): " + questao.answer);
-        
-    //     console.log(analysis.dimension_count[questao.question.dimension])
-    //     // console.log(questao.question.dimension)
-    // }
-
-
+    }
+      
     function sourceAreaChange() {
         let sourceValue = document.getElementById("questionSource"+questao.id).value
         handleSourceChange(sourceValue,questao)
@@ -36,11 +41,15 @@ const Questions = ({ questao, analysis, setDimensions, handleCheckBoxClick, hand
         let justificationValue = document.getElementById("questionJustification"+questao.id).value
         handleJustificationChange(justificationValue,questao)
     }
+
+
+
+    // document.onload = initAnswer();
     return <>
             <div className='question-container'>
 
                 {/* <div className='negative-container'> */}
-                    <button className='negative-btn'>X</button>
+                    <button className='negative-btn' onClick={answerHandler}>X</button>
                 {/* </div> */}
                 
 
@@ -50,13 +59,12 @@ const Questions = ({ questao, analysis, setDimensions, handleCheckBoxClick, hand
                     
                     {/* <div className='alig-areas'> */}
 
-                        <div className='questionArea'>
+                        <div className='questionArea' id={'question'+questao.id}>
                         {questao.question.body} 
                         
                         </div>
-                        
-                        <br></br>
-                        <div className='justification-container'>
+
+                        <div className='justification-container' >
                             Justificativa:<br></br> <textarea  className='justificationArea' id = {'questionJustification'+questao.id} onChange={justificationAreaChange}>{questao.justification}</textarea>  <br></br>
                         </div>
                         
@@ -77,7 +85,7 @@ const Questions = ({ questao, analysis, setDimensions, handleCheckBoxClick, hand
                     {/* </div> */}
                 </div>
                 {/* <div className='positive-container'> */}
-                    <button className='positive-btn'>V</button>   
+                    <button className='positive-btn' onClick={answerHandler}>V</button>   
                 {/* </div> */}
 
 

--- a/Frontend/src/components/Analyst/analysis/Questions.js
+++ b/Frontend/src/components/Analyst/analysis/Questions.js
@@ -37,19 +37,37 @@ const Questions = ({ questao, analysis, setDimensions, handleCheckBoxClick, hand
         handleJustificationChange(justificationValue,questao)
     }
     return <>
-            <div className='listQuestoes'>
-                {/* <div className='question-and-awnser'> */}
-                        Questão: {questao.question.body} 
-                        <label class="switch">
-                            <input type="checkbox" onClickCapture={() => handleCheckBoxClick(questao)} defaultChecked={questao.answer}>
-                            </input>
-                            <span class="slider round">
-                            </span>
-                        </label> 
-                {/* </div> */}
+            <div className='question-container'>
+
+            
+                <div className='full-question-area'>
+                    {/* <div className='question-and-awnser'> */}
+                    <button className='negative-btn'>X</button>
+                    
+                    {/* <div className='alig-areas'> */}
+                        <div className='questionArea'>
+                            {questao.question.body} 
+                            </div>
+                    {/* </div> */}
+
+                    <button className='positive-btn'>V</button>      
+                            {/* <label class="switch">
+                                <input type="checkbox" onClickCapture={() => handleCheckBoxClick(questao)} defaultChecked={questao.answer}></input>
+                                <span class="slider round">
+                                </span>
+                            </label>  */}
+                    {/* </div> */}
+                </div>
+
+                <div className='source-container'>
+                    Fonte:<br></br> <textarea  className='sourceArea' id = {'questionSource'+questao.id} onChange={sourceAreaChange}>{questao.source}</textarea> <br></br>
+                </div>
+
+                <div className='justification-container'>
+                    Justificativa:<br></br> <textarea  className='justificationArea' id = {'questionJustification'+questao.id} onChange={justificationAreaChange}>{questao.justification}</textarea>  <br></br>
+                </div>
+
             </div>
-            Fonte:<br></br> <textarea  className='sourceArea' id = {'questionSource'+questao.id} onChange={sourceAreaChange}>{questao.source}</textarea> <br></br>
-            Justificativa:<br></br> <textarea  className='justificationArea' id = {'questionJustification'+questao.id} onChange={justificationAreaChange}>{questao.justification}</textarea>  <br></br>
             </>
 }; 
 

--- a/Frontend/src/components/Analyst/analysis/QuestionsFinished.js
+++ b/Frontend/src/components/Analyst/analysis/QuestionsFinished.js
@@ -25,51 +25,48 @@ const QuestionsFinished = ({ questao}) => {
 
     // document.onload = initAnswer();
     return <>
-            <div className='question-container'>
+        <div className='question-container'>
 
-                {/* <div className='negative-container'> */}
-                    <button className='negative-btn'>X</button>
-                {/* </div> */}
+            {/* <div className='negative-container'> */}
+                <button className='negative-btn' >
+                <img src="../images/x.svg" alt="X"/>
+                </button>
+            {/* </div> */}
+
+
+            <div className='full-question-area'>
+                {/* <div className='question-and-awnser'> */}
                 
+                
+                {/* <div className='alig-areas'> */}
+                    <div className='questionArea' id={'question'+questao.id} >
+                        {questao.question.body} 
+                    </div>
 
-                <div className='full-question-area'>
-                    {/* <div className='question-and-awnser'> */}
-                    
-                    
-                    {/* <div className='alig-areas'> */}
-
-                        <div className='questionArea' id={'question'+questao.id}>
-                            {questao.question.body} 
-                        
-                        </div>
-
+                    <div className='justi-src-container'>
                         <div className='justification-container' >
-                            <div className='just-tittle'>Justificativa:</div> <textarea  className='justificationArea' id = {'questionJustification'+questao.id} >{questao.justification}</textarea>  <br></br>
+                            <div className='just-tittle'>Justificativa:</div>
+                            <textarea readOnly='true' className='justificationArea' id = {'questionJustification'+questao.id}>{questao.justification}</textarea>  <br></br>
                         </div>
                         
                         <div className='source-container'>
-                            <div className='source-tittle'>Fonte:</div> <textarea  className='sourceArea' id = {'questionSource'+questao.id} >{questao.source}</textarea> <br></br>
+                            <div className='source-tittle'>Fonte:</div>
+                            <textarea readOnly='true' className='sourceArea' id = {'questionSource'+questao.id} >{questao.source}</textarea> <br></br>
                         </div>
+                    </div> 
 
-
-
-                    {/* </div> */}
-
-                       
-                            {/* <label class="switch">
-                                <input type="checkbox" onClickCapture={() => handleCheckBoxClick(questao)} defaultChecked={questao.answer}></input>
-                                <span class="slider round">
-                                </span>
-                            </label>  */}
-                    {/* </div> */}
-                </div>
-                {/* <div className='positive-container'> */}
-                    <button className='positive-btn'>V</button>   
-                {/* </div> */}
 
 
             </div>
-            </>
+            {/* <div className='positive-container'> */}
+                <button className='positive-btn'>
+                    <img src="../images/v.svg" alt="V"/>
+                </button>   
+            {/* </div> */}
+
+
+        </div>
+        </>
 }; 
 
 export default QuestionsFinished;

--- a/Frontend/src/components/Analyst/analysis/QuestionsFinished.js
+++ b/Frontend/src/components/Analyst/analysis/QuestionsFinished.js
@@ -1,9 +1,10 @@
-import React, {useEffect} from 'react';
+import React, {useEffect, useState} from 'react';
 import './Question.css'
+import Collapse from 'react-bootstrap/Collapse';
 
 const QuestionsFinished = ({ questao}) => {
     
-
+    const [active, setActive] = useState(false);
     useEffect(() => {
         // setQuest(questao)
         initAnswer()
@@ -19,9 +20,9 @@ const QuestionsFinished = ({ questao}) => {
         }
     }
          
-
-
-
+    function questionClickHandler() {
+        setActive(!active)
+    }
 
     // document.onload = initAnswer();
     return <>
@@ -39,21 +40,24 @@ const QuestionsFinished = ({ questao}) => {
                 
                 
                 {/* <div className='alig-areas'> */}
-                    <div className='questionArea' id={'question'+questao.id} >
+                    <div className='questionArea' id={'question'+questao.id} onClick= {questionClickHandler}>
                         {questao.question.body} 
                     </div>
 
-                    <div className='justi-src-container'>
-                        <div className='justification-container' >
-                            <div className='just-tittle'>Justificativa:</div>
-                            <textarea readOnly='true' className='justificationArea' id = {'questionJustification'+questao.id}>{questao.justification}</textarea>  <br></br>
-                        </div>
-                        
-                        <div className='source-container'>
-                            <div className='source-tittle'>Fonte:</div>
-                            <textarea readOnly='true' className='sourceArea' id = {'questionSource'+questao.id} >{questao.source}</textarea> <br></br>
-                        </div>
-                    </div> 
+                    <Collapse in={active}>
+                        <div className='justi-src-container'>
+                            <div className='justification-container' >
+                                <div className='just-tittle'>Justificativa:</div>
+                                <textarea readOnly='true' className='justificationArea' id = {'questionJustification'+questao.id}>{questao.justification}</textarea>  <br></br>
+                            </div>
+                            
+                            <div className='source-container'>
+                                <div className='source-tittle'>Fonte:</div>
+                                <textarea readOnly='true' className='sourceArea' id = {'questionSource'+questao.id} >{questao.source}</textarea> <br></br>
+                            </div>
+                        </div> 
+                    </Collapse>
+
 
 
 

--- a/Frontend/src/components/Analyst/analysis/QuestionsFinished.js
+++ b/Frontend/src/components/Analyst/analysis/QuestionsFinished.js
@@ -1,10 +1,9 @@
-import React, {useEffect, useState} from 'react';
+import React, {useEffect} from 'react';
 import './Question.css'
-import Collapse from 'react-bootstrap/Collapse';
 
 const QuestionsFinished = ({ questao}) => {
     
-    const [active, setActive] = useState(false);
+
     useEffect(() => {
         // setQuest(questao)
         initAnswer()
@@ -20,9 +19,9 @@ const QuestionsFinished = ({ questao}) => {
         }
     }
          
-    function questionClickHandler() {
-        setActive(!active)
-    }
+
+
+
 
     // document.onload = initAnswer();
     return <>
@@ -40,24 +39,21 @@ const QuestionsFinished = ({ questao}) => {
                 
                 
                 {/* <div className='alig-areas'> */}
-                    <div className='questionArea' id={'question'+questao.id} onClick= {questionClickHandler}>
+                    <div className='questionArea' id={'question'+questao.id} >
                         {questao.question.body} 
                     </div>
 
-                    <Collapse in={active}>
-                        <div className='justi-src-container'>
-                            <div className='justification-container' >
-                                <div className='just-tittle'>Justificativa:</div>
-                                <textarea readOnly='true' className='justificationArea' id = {'questionJustification'+questao.id}>{questao.justification}</textarea>  <br></br>
-                            </div>
-                            
-                            <div className='source-container'>
-                                <div className='source-tittle'>Fonte:</div>
-                                <textarea readOnly='true' className='sourceArea' id = {'questionSource'+questao.id} >{questao.source}</textarea> <br></br>
-                            </div>
-                        </div> 
-                    </Collapse>
-
+                    <div className='justi-src-container'>
+                        <div className='justification-container' >
+                            <div className='just-tittle'>Justificativa:</div>
+                            <textarea readOnly='true' className='justificationArea' id = {'questionJustification'+questao.id}>{questao.justification}</textarea>  <br></br>
+                        </div>
+                        
+                        <div className='source-container'>
+                            <div className='source-tittle'>Fonte:</div>
+                            <textarea readOnly='true' className='sourceArea' id = {'questionSource'+questao.id} >{questao.source}</textarea> <br></br>
+                        </div>
+                    </div> 
 
 
 

--- a/Frontend/src/components/Analyst/analysis/QuestionsFinished.js
+++ b/Frontend/src/components/Analyst/analysis/QuestionsFinished.js
@@ -1,21 +1,75 @@
-import React from 'react';
-import './Analysis.css'
+import React, {useEffect} from 'react';
+import './Question.css'
 
-const QuestionsFinished = ({ questao }) => {
+const QuestionsFinished = ({ questao}) => {
+    
 
-    return <><div className='listQuestoes'>
-                Questão: {questao.question.body} 
-                <label class="switch">
-                    <input type="checkbox" disabled="disabled" defaultChecked={questao.answer}>
-                    </input>
-                    <span class="slider round">
-                    </span>
-                </label> 
-        
+    useEffect(() => {
+        // setQuest(questao)
+        initAnswer()
+    },[])
+
+    function initAnswer(){
+        var box = document.getElementById('question'+questao.id)
+        if (questao.answer){
+            box.style.animation = "positive 0.125s linear forwards";
+        }
+        else{
+            box.style.animation = "negative 0.125s linear forwards";
+        }
+    }
+         
+
+
+
+
+    // document.onload = initAnswer();
+    return <>
+            <div className='question-container'>
+
+                {/* <div className='negative-container'> */}
+                    <button className='negative-btn'>X</button>
+                {/* </div> */}
+                
+
+                <div className='full-question-area'>
+                    {/* <div className='question-and-awnser'> */}
+                    
+                    
+                    {/* <div className='alig-areas'> */}
+
+                        <div className='questionArea' id={'question'+questao.id}>
+                        {questao.question.body} 
+                        
+                        </div>
+
+                        <div className='justification-container' >
+                            Justificativa:<br></br> <textarea  className='justificationArea' id = {'questionJustification'+questao.id} >{questao.justification}</textarea>  <br></br>
+                        </div>
+                        
+                        <div className='source-container'>
+                            Fonte:<br></br> <textarea  className='sourceArea' id = {'questionSource'+questao.id} >{questao.source}</textarea> <br></br>
+                        </div>
+
+
+
+                    {/* </div> */}
+
+                       
+                            {/* <label class="switch">
+                                <input type="checkbox" onClickCapture={() => handleCheckBoxClick(questao)} defaultChecked={questao.answer}></input>
+                                <span class="slider round">
+                                </span>
+                            </label>  */}
+                    {/* </div> */}
+                </div>
+                {/* <div className='positive-container'> */}
+                    <button className='positive-btn'>V</button>   
+                {/* </div> */}
+
+
             </div>
-        Fonte:<br></br> <textarea readonly  = 'true' className='sourceArea' id = {'questionSource'+questao.id} >{questao.source}</textarea> <br></br>
-        Justificativa:<br></br> <textarea readonly = 'true'  className='justificationArea' id = {'questionJustification'+questao.id}>{questao.justification}</textarea>  <br></br>
-        </>
+            </>
 }; 
 
 export default QuestionsFinished;

--- a/Frontend/src/components/Analyst/analysis/QuestionsFinished.js
+++ b/Frontend/src/components/Analyst/analysis/QuestionsFinished.js
@@ -39,16 +39,16 @@ const QuestionsFinished = ({ questao}) => {
                     {/* <div className='alig-areas'> */}
 
                         <div className='questionArea' id={'question'+questao.id}>
-                        {questao.question.body} 
+                            {questao.question.body} 
                         
                         </div>
 
                         <div className='justification-container' >
-                            Justificativa:<br></br> <textarea  className='justificationArea' id = {'questionJustification'+questao.id} >{questao.justification}</textarea>  <br></br>
+                            <div className='just-tittle'>Justificativa:</div> <textarea  className='justificationArea' id = {'questionJustification'+questao.id} >{questao.justification}</textarea>  <br></br>
                         </div>
                         
                         <div className='source-container'>
-                            Fonte:<br></br> <textarea  className='sourceArea' id = {'questionSource'+questao.id} >{questao.source}</textarea> <br></br>
+                            <div className='source-tittle'>Fonte:</div> <textarea  className='sourceArea' id = {'questionSource'+questao.id} >{questao.source}</textarea> <br></br>
                         </div>
 
 


### PR DESCRIPTION
Nessa Pull Request foi implementado a melhoria visual requisitada na issue #82

## Problema

O problema se dava devido ao fato da tela para fazer a análise e visualizar análises já feita não estavam visualmente agradáveis.

## Implementação

- Os Icones foram adicionados nos botões. Foi adicionado simplesmente os svg dentro dos botões.

- A animação foi ajustada (agora não teletransporta mais). Para a animação eu utilizei os https://github.com/Keyframes do proprio css, com as respectivas animações de slide. Para que a animação seja executada, foi utilizada uma função que determina o style.animation adequado do componente baseado no atual estado da resposta.

- Os textos foram ajustados no centro. Basicamente mudei o alinhamento dos textos no css.

## Como Testar

Basta ir em uma das telas (fazer análise ou a tela de visualizar uma nálise já finalizada) e ver as melhorias, testas os botões, ver a interface e confirmar se as informações ainda estão sendo salvas no backend da maneira correta.

![image](https://user-images.githubusercontent.com/84993974/194777066-e4d7ab56-d321-474c-b27e-db2f4e6e78ce.png)


## Objetivos

Fix #82
