### PR TITLE
[Feature] Barra de progresso implementada e opção de questão não respondida

### DIFF
--- a/Frontend/src/components/Analyst/analysis/Analysis.css
+++ b/Frontend/src/components/Analyst/analysis/Analysis.css
@@ -4,8 +4,76 @@
   
 }
 
+/* Progress Bar */
+
+.progress-container{
+  background-color: #D9D9D9;
+  width: 100%;
+  height: 7.5vh;
+  position: fixed;
+  z-index: 100;
+  bottom: 0;
+
+  display: flex;
+  flex-direction: row;
+  justify-content: space-evenly;
+  text-align: center;
+  align-items: center;
+}
+
+.progress-container .btns{
+  /* margin-top: 20px;
+  background-color: rgb(56, 57, 58);
+  border-radius: 5px;
+  color: white;
+  border:none;
+  width: 75px;
+  height: 50px; */
+}
+
+
+.progress-container .bar {
+  width: 75%;
+  /* margin-left: 10%; */
+}
+
+.progress-container .btns-container {
+  /* width: 50%; */
+  margin-right: 10%;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  text-align: center;
+  align-items: center;
+}
+
+.progress {
+  background-color: #F5F5F5;
+  color: #21f33d;
+  height: 5vh;
+  border-radius: 15px;
+  margin-left: 5%;
+  margin-right: 5%;
+}
+
+.progress .progress-bar{
+  background-color: #1BB55C;;
+  color: white;
+  font-size: large;
+  font-weight: bold;
+}
+
+
+.pop{
+  position: absolute;
+  
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
 .finish_him {
-  position:absolute;
+
+
   justify-content: center;
   align-items: center;
   left: 50vh;
@@ -16,9 +84,6 @@
   display: flex;
   flex-direction: column;
   padding: 2rem;
-}
-.inp-pass {
-
 }
 
 .finish-Buttons {
@@ -51,11 +116,13 @@
 
 
  .btns{
-  margin-top: 20px;
-  background-color: rgb(56, 57, 58);
-  border-radius: 5px;
+  /* margin-top: 20px; */
+  background-color: #1BB55C;
+  border-radius: 15px;
   color: white;
   border:none;
-  width: 75px;
-  height: 50px;
+  width: 10%;
+  height: 5vh;
+  font-weight: bold;
+  font-size: large;
 }

--- a/Frontend/src/components/Analyst/analysis/Analysis.css
+++ b/Frontend/src/components/Analyst/analysis/Analysis.css
@@ -76,22 +76,43 @@
 
   justify-content: center;
   align-items: center;
-  left: 50vh;
+  /* left: 50vh; */
   width: 20vw;
-  height: 10vw;
-  background-color: #21f33d;
+  height: 15vw;
+  max-width: 100%;
+  max-height: 100%;
+  background-color: #F5F5F5;
   justify-items: center;
   display: flex;
   flex-direction: column;
   padding: 2rem;
+
+  font-size: large;
+  font-weight: bold;
+  text-align: center;
+
+  border: 3px solid;
+  border-color: black;
+  border-radius: 20px;
+}
+
+.finish_him .btns{
+  width: 30%;
 }
 
 .finish-Buttons {
   margin-top: 20px;
+  margin-bottom: 20px;
   display: flex;
   justify-content: space-between;
+
+  width: 100%;
 }
 
+.inp-pass{
+  border: 3px solid;
+  border-radius: 10px ;
+}
 
 
 .example-warper {
@@ -125,4 +146,8 @@
   height: 5vh;
   font-weight: bold;
   font-size: large;
+}
+
+.btns:hover{
+  background-color:#007b33 ;
 }

--- a/Frontend/src/components/Analyst/analysis/Analysis.css
+++ b/Frontend/src/components/Analyst/analysis/Analysis.css
@@ -109,6 +109,33 @@
   width: 100%;
 }
 
+.analysis_not_finished{
+  justify-content: space-evenly;
+  align-items: center;
+  /* left: 50vh; */
+  width: 20vw;
+  height: 15vw;
+  max-width: 100%;
+  max-height: 100%;
+  background-color: #F5F5F5;
+  justify-items: center;
+  display: flex;
+  flex-direction: column;
+  padding: 2rem;
+
+  font-size: large;
+  font-weight: bold;
+  text-align: center;
+
+  border: 3px solid;
+  border-color: black;
+  border-radius: 20px;
+}
+
+.analysis_not_finished .btns{
+  width: 100%;
+}
+
 .inp-pass{
   border: 3px solid;
   border-radius: 10px ;
@@ -150,4 +177,20 @@
 
 .btns:hover{
   background-color:#007b33 ;
+}
+
+.btns-not-finished{
+    /* margin-top: 20px; */
+    background-color: #929292;
+    border-radius: 15px;
+    color: white;
+    border:none;
+    width: 10%;
+    height: 5vh;
+    font-weight: bold;
+    font-size: large;
+}
+
+.btns-not-finished:hover{
+  background-color: #4a4a4a;
 }

--- a/Frontend/src/components/Analyst/analysis/AnalysisDetails.js
+++ b/Frontend/src/components/Analyst/analysis/AnalysisDetails.js
@@ -231,9 +231,9 @@ const Analysis = ({ analise }) => {
     // console.log(inp)
   }
 
-  function progressTest(){
-    setCountRate(analysisCountRate+10)
-  }
+  // function progressTest(){
+  //   setCountRate(analysisCountRate+10)
+  // }
 
     if (analysis.status < 2 ){
         return (<div className='listAnalise'>
@@ -248,7 +248,7 @@ const Analysis = ({ analise }) => {
 
 
         
-        <button className='btns' onClick={progressTest}>teste</button>
+        {/* <button className='btns' onClick={progressTest}>teste</button> */}
 
 
         <div className='progress-container'>

--- a/Frontend/src/components/Analyst/analysis/AnalysisDetails.js
+++ b/Frontend/src/components/Analyst/analysis/AnalysisDetails.js
@@ -90,15 +90,32 @@ const Analysis = ({ analise }) => {
 
     }
 
-    function handleCheckBoxClick(quest) {
-      quest.answer= !quest.answer;
+    function handleCheckBoxClick(quest,answer) {
+      let wasNotAnswered = false
+      if (quest.answer === 2){
+        wasNotAnswered = true
+      }
+      // quest.answer= !quest.answer;
+      // quest.answer= 2;
+      if (answer === true){
+        quest.answer = 1;
+      }
+      if (answer === false){
+        quest.answer = 0;
+      }
 
       let valor = 1;
-      if(quest.answer === true){
+      if(quest.answer === 1){
         valor = 1;
       }
-      else{
-        valor = -1;
+      if(quest.answer === 0){
+        if (wasNotAnswered === false){
+          valor = -1;
+        }
+        else{
+          valor = 0
+        }
+        
       }
 
       analysis.dimension_count[quest.question.dimension].checked += valor
@@ -108,7 +125,7 @@ const Analysis = ({ analise }) => {
 
     //   console.log("resposta da questão ("+ questao.question.body + "): " + questao.answer);
     
-    console.log(dimensions);
+    console.log(quest.answer);
     // console.log(questao.question.dimension)
   }
 
@@ -138,9 +155,6 @@ const Analysis = ({ analise }) => {
     setCount(analysisCount+10)
   }
 
-
-
-    console.log(analise.company.tradeName)
     if (analysis.status < 2 ){
         return (<div className='listAnalise'>
         Empresa: {analysis.company.tradeName}<br></br>

--- a/Frontend/src/components/Analyst/analysis/AnalysisDetails.js
+++ b/Frontend/src/components/Analyst/analysis/AnalysisDetails.js
@@ -20,7 +20,12 @@ const Analysis = ({ analise }) => {
 
 
     const [analysis,setAnalysis] = useState("placeholder");
-    const [analysisCount,setCount] = useState(0);
+
+    // const [analysisTotalCount,setTotalCount] = useState(1);
+    // const [analysisAnsweredCount,setAnsweredCount] = useState(0);
+    const [analysisCountRate,setCountRate] = useState(0);
+    const [totalQuestions,setTotalQuestions] = useState(1);
+
     const [dimensions,setDimensions] = useState({});
 
     const [isOpen, setIsOpen] = useState(false); //popup
@@ -40,13 +45,61 @@ const Analysis = ({ analise }) => {
         
         setDimensions(response.data.analysis.dimension_count)
         setAnalysis(response.data.analysis)
-        setCount(response.data.analysis.questao_set.length)
+
+        setTotalQuestions(response.data.analysis.questao_set.length)
+        // setTotalCount(response.data.analysis.questao_set.length)
+        // calcAnswered(response.data.analysis.questao_set)
+        // let answered = calcAnswered(response.data.analysis.questao_set)
+
+        let answered = calcAnswered(response.data.analysis.questao_set);
+        // for (let i = 0; i < response.data.analysis.questao_set.length; i++){
+        //   if (response.data.analysis.questao_set[i].answer != 2) {
+        //     answered += 1
+        //   }
+        //   // console.log(questions_set[i].answer)
+        //   // setAnsweredCount(answered);
+        // }
+
+        // setAnsweredCount(answered);
+        // setTotalCount(response.data.analysis.questao_set.length);
+  
+        setCountRate(((answered/response.data.analysis.questao_set.length)*100).toFixed(2));
+
+        // console.log("rate inicial: " + analysisCountRate)
+      
+
+        // setCountRate((answered/response.data.analysis.questao_set.length)*100)
+
+        // calcAndSetRate(response.data.analysis.questao_set, response.data.analysis.questao_set.length)
     
-        console.log(response.data.analysis)
-        
-    
+        // console.log(response.data.analysis)
         
       }
+
+    function calcAnswered(questions_set){
+      let answered = 0;
+      for (let i = 0; i < questions_set.length; i++){
+        if (questions_set[i].answer != 2) {
+          answered += 1
+        }
+        // console.log(questions_set[i].answer)
+        // setAnsweredCount(answered);
+      }
+      // console.log("respondidas: " + answered)
+      return answered;
+    }
+
+
+
+    // function calcAndSetRate(questions_set,total){
+    //   let answered = calcAnswered(questions_set);
+
+    //   setAnsweredCount(answered);
+    //   setTotalCount(total);
+
+    //   setCountRate((answered/total)*100);
+    // }
+
 
       // if (analysis === "placeholder"){
       //   analysisDetail()
@@ -95,6 +148,10 @@ const Analysis = ({ analise }) => {
       if (quest.answer === 2){
         wasNotAnswered = true
       }
+      // if (wasNotAnswered === true){
+      //   setAnsweredCount(analysisAnsweredCount+1)
+      //   console.log ("contador total de ")
+      // }
       // quest.answer= !quest.answer;
       // quest.answer= 2;
       if (answer === true){
@@ -122,10 +179,33 @@ const Analysis = ({ analise }) => {
       const copy = analysis.dimension_count
       setDimensions({...copy})
 
+      // calcAndSetRate(analysis.questao_set,analysis.questao_set.length)
+      // let answered = calcAnswered(analysis.questao_set);
+
+      // setAnsweredCount(answered);
+      // setTotalCount(analysis.questao_set.length);
+      
+
+      let answered = calcAnswered(analysis.questao_set);
+      // for (let i = 0; i < analysis.questao_set.length; i++){
+      //   if (analysis.questao_set[i].answer != 2) {
+      //     answered += 1
+      //   }
+      //   // console.log(questions_set[i].answer)
+      //   // setAnsweredCount(answered);
+      // }
+
+      // setAnsweredCount(answered);
+      // setTotalCount(response.data.analysis.questao_set.length);
+
+      setCountRate(((answered/analysis.questao_set.length)*100).toFixed(2));
+
+      // console.log("respondidas: " + analysisAnsweredCount + " e total: " + analysisTotalCount + " e a taxa: " + analysisCountRate)
+
 
     //   console.log("resposta da questão ("+ questao.question.body + "): " + questao.answer);
     
-    console.log(quest.answer);
+    // console.log(quest.answer)
     // console.log(questao.question.dimension)
   }
 
@@ -152,7 +232,7 @@ const Analysis = ({ analise }) => {
   }
 
   function progressTest(){
-    setCount(analysisCount+10)
+    setCountRate(analysisCountRate+10)
   }
 
     if (analysis.status < 2 ){
@@ -173,7 +253,7 @@ const Analysis = ({ analise }) => {
 
         <div className='progress-container'>
           <div className='bar'>
-            <ProgressBar now={analysisCount} color="green" label={analysisCount + "%"} className="progress"/>
+            <ProgressBar now={analysisCountRate} color="green" label={analysisCountRate + "%"} className="progress"/>
           </div>
 
           {/* <div className='btns-container'> */}

--- a/Frontend/src/components/Analyst/analysis/AnalysisDetails.js
+++ b/Frontend/src/components/Analyst/analysis/AnalysisDetails.js
@@ -23,6 +23,8 @@ const Analysis = ({ analise }) => {
     const [analysisCount,setCount] = useState(0);
     const [dimensions,setDimensions] = useState({});
 
+    const [isOpen, setIsOpen] = useState(false); //popup
+
     useEffect(() => {
       analysisDetail()
         
@@ -136,6 +138,8 @@ const Analysis = ({ analise }) => {
     setCount(analysisCount+10)
   }
 
+
+
     console.log(analise.company.tradeName)
     if (analysis.status < 2 ){
         return (<div className='listAnalise'>
@@ -165,13 +169,21 @@ const Analysis = ({ analise }) => {
 
             <button className='btns' onClick={handleSaveClick}>Salvar</button>
 
-            <Popup trigger={<button className='btns'>Finalizar</button>} anchor={null} className="pop" modal nested>
+            <Popup trigger={<button className='btns'>Finalizar</button>} className="pop" modal nested
+              open={isOpen}
+              onOpen={() => setIsOpen(!isOpen)}>
+
               <div className='finish_him'>
                 <div className='title'>Insira sua senha</div>
                 <input className='inp-pass' id='password-conf' type="password"></input>
                 <div className='title'>Deseja finalizar a análise?</div>
-                <div className='finish-Buttons'><button onClick={() => {confirmButtonHandler(document.getElementById("password-conf").value)}}>SIM</button><button>NÃO</button></div>
+
+                <div className='finish-Buttons'>
+                  <button className='btns' onClick={() => {confirmButtonHandler(document.getElementById("password-conf").value)}}>SIM</button>
+                  <button className='btns' onClick={() => setIsOpen(!isOpen)}>NÃO</button>
+                </div>
               </div>
+              
             </Popup>
             
           {/* </div> */}

--- a/Frontend/src/components/Analyst/analysis/AnalysisDetails.js
+++ b/Frontend/src/components/Analyst/analysis/AnalysisDetails.js
@@ -263,22 +263,37 @@ const Analysis = ({ analise }) => {
 
             <button className='btns' onClick={handleSaveClick}>Salvar</button>
 
-            <Popup trigger={<button className='btns'>Finalizar</button>} className="pop" modal nested
+            {analysisCountRate >= 100 ? 
+              <Popup trigger={<button className='btns'>Finalizar</button>} className="pop" modal nested
+                open={isOpen}
+                onOpen={() => setIsOpen(!isOpen)}>
+
+                <div className='finish_him'>
+                  <div className='title'>Insira sua senha</div>
+                  <input className='inp-pass' id='password-conf' type="password"></input>
+                  <div className='title'>Deseja finalizar a análise?</div>
+
+                  <div className='finish-Buttons'>
+                    <button className='btns' onClick={() => {confirmButtonHandler(document.getElementById("password-conf").value)}}>SIM</button>
+                    <button className='btns' onClick={() => setIsOpen(!isOpen)}>NÃO</button>
+                  </div>
+                </div>
+                
+              </Popup>
+            :
+            <Popup trigger={<button className='btns-not-finished'>Finalizar</button>} className="pop" modal nested
               open={isOpen}
               onOpen={() => setIsOpen(!isOpen)}>
 
-              <div className='finish_him'>
-                <div className='title'>Insira sua senha</div>
-                <input className='inp-pass' id='password-conf' type="password"></input>
-                <div className='title'>Deseja finalizar a análise?</div>
-
+              <div className='analysis_not_finished'>
+                <div className='title'>Você ainda não concluiu sua análise, por favor, responda todas as perguntas para poder finalizar</div>
                 <div className='finish-Buttons'>
-                  <button className='btns' onClick={() => {confirmButtonHandler(document.getElementById("password-conf").value)}}>SIM</button>
-                  <button className='btns' onClick={() => setIsOpen(!isOpen)}>NÃO</button>
+                  <button className='btns' onClick={() => setIsOpen(!isOpen)}>Voltar para a análise</button>
                 </div>
               </div>
-              
             </Popup>
+            }
+
             
           {/* </div> */}
 

--- a/Frontend/src/components/Analyst/analysis/AnalysisDetails.js
+++ b/Frontend/src/components/Analyst/analysis/AnalysisDetails.js
@@ -8,6 +8,9 @@ import axios from 'axios';
 import Popup from 'reactjs-popup';
 import { Navigate } from 'react-router-dom';
 
+import ProgressBar from 'react-bootstrap/ProgressBar';
+import 'bootstrap/dist/css/bootstrap.min.css';
+
 
 const Analysis = ({ analise }) => {
 
@@ -17,11 +20,14 @@ const Analysis = ({ analise }) => {
 
 
     const [analysis,setAnalysis] = useState("placeholder");
+    const [analysisCount,setCount] = useState(0);
     const [dimensions,setDimensions] = useState({});
 
     useEffect(() => {
-        analysisDetail()
+      analysisDetail()
+        
     },[])
+
 
     async function analysisDetail() {
         let response = await axios.get(
@@ -29,9 +35,13 @@ const Analysis = ({ analise }) => {
           { withCredentials: true }
         )
         .then()
+        
         setDimensions(response.data.analysis.dimension_count)
         setAnalysis(response.data.analysis)
+        setCount(response.data.analysis.questao_set.length)
+    
         console.log(response.data.analysis)
+        
     
         
       }
@@ -122,31 +132,53 @@ const Analysis = ({ analise }) => {
     // console.log(inp)
   }
 
+  function progressTest(){
+    setCount(analysisCount+10)
+  }
+
     console.log(analise.company.tradeName)
     if (analysis.status < 2 ){
         return (<div className='listAnalise'>
         Empresa: {analysis.company.tradeName}<br></br>
         {/* Questões: {analise.questoes} <br></br> */}
-
         Score D1: {((dimensions['D1'].checked)/dimensions['D1'].amount).toFixed(2)}<br></br>
         Score D2: {((dimensions['D2'].checked)/dimensions['D2'].amount).toFixed(2)}<br></br>
         Score D3: {((dimensions['D3'].checked)/dimensions['D3'].amount).toFixed(2)}<br></br>
         Score D4: {((dimensions['D4'].checked)/dimensions['D4'].amount).toFixed(2)}<br></br>
         Score TOTAL: {((((dimensions['D1'].checked)/dimensions['D1'].amount) + ((dimensions['D2'].checked)/dimensions['D2'].amount) + ((dimensions['D3'].checked)/dimensions['D3'].amount) + ((dimensions['D4'].checked)/dimensions['D4'].amount))/4).toFixed(2)} <br></br>
         
-        <button className='btns' onClick={handleSaveClick}>Salvar</button>
 
-        <Popup trigger={<button className='btns'>Finalizar</button>}
-              anchor={null}>
-          <div className='finish_him'>
-            <div className='title'>Insira sua senha</div>
-            <input className='inp-pass' id='password-conf' type="password"></input>
-            <div className='title'>Deseja finalizar a análise?</div>
-            <div className='finish-Buttons'><button onClick={() => {confirmButtonHandler(document.getElementById("password-conf").value)}}>SIM</button><button>NÃO</button></div>
+
+        
+        <button className='btns' onClick={progressTest}>teste</button>
+
+
+        <div className='progress-container'>
+          <div className='bar'>
+            <ProgressBar now={analysisCount} color="green" label={analysisCount + "%"} className="progress"/>
           </div>
-        </Popup><br></br><br></br>
 
-        Questões: {analysis.questao_set.map((questao) => (<Questions questao={questao} analysis={analysis} setDimensions={setDimensions} handleCheckBoxClick={handleCheckBoxClick} handleSourceChange={handleSourceChange} handleJustificationChange={handleJustificationChange}/>))}
+          {/* <div className='btns-container'> */}
+            
+            {/* <div>{analysisCount}</div>
+            <button onClick={progressTest}>teste</button> */}
+
+            <button className='btns' onClick={handleSaveClick}>Salvar</button>
+
+            <Popup trigger={<button className='btns'>Finalizar</button>} anchor={null} className="pop" modal nested>
+              <div className='finish_him'>
+                <div className='title'>Insira sua senha</div>
+                <input className='inp-pass' id='password-conf' type="password"></input>
+                <div className='title'>Deseja finalizar a análise?</div>
+                <div className='finish-Buttons'><button onClick={() => {confirmButtonHandler(document.getElementById("password-conf").value)}}>SIM</button><button>NÃO</button></div>
+              </div>
+            </Popup>
+            
+          {/* </div> */}
+
+        </div>
+
+        {analysis.questao_set.map((questao) => (<Questions questao={questao} analysis={analysis} setDimensions={setDimensions} handleCheckBoxClick={handleCheckBoxClick} handleSourceChange={handleSourceChange} handleJustificationChange={handleJustificationChange}/>))}
         {/* Score D1: {analise.dimension_count['D1'].checked / analise.dimension_count['D1'].amount}<br></br> */}
 
         {/* Score Atual: {analise.score}<br></br><br></br> */}

--- a/Frontend/src/components/Analyst/analysis/Question.css
+++ b/Frontend/src/components/Analyst/analysis/Question.css
@@ -223,6 +223,7 @@
 
 }
 
+
 @keyframes negative-neutral {
     100% {transform: translate(6.25%, 0%);}
 }

--- a/Frontend/src/components/Analyst/analysis/Question.css
+++ b/Frontend/src/components/Analyst/analysis/Question.css
@@ -13,7 +13,7 @@
 }
 
 .full-question-area{
-    --quest-width: 90%;
+    --quest-width: 85%;
     max-height: 100%;
     /* background-color: #F0F0F0; */
     border-radius: 20px;
@@ -225,30 +225,30 @@
 
 
 @keyframes negative-neutral {
-    100% {transform: translate(6.25%, 0%);}
+    100% {transform: translate(9%, 0%);}
 }
 
 @keyframes positive-neutral {
-    100% {transform: translate(-6.25%, 0%);}
+    100% {transform: translate(-9%, 0%);}
 }
 
 
 @keyframes negative {
     from {
-        transform: translate(-6.25%,0%);
+        transform: translate(-9%,0%);
       }
     
       to {
-        transform: translate(6.25%,0%);
+        transform: translate(9%,0%);
       }
 }
 
 @keyframes positive {
     from {
-        transform: translate(6.25%,0%);
+        transform: translate(9%,0%);
       }
     
       to {
-        transform: translate(-6.25%,0%);
+        transform: translate(-9%,0%);
       }
 }

--- a/Frontend/src/components/Analyst/analysis/Questions.js
+++ b/Frontend/src/components/Analyst/analysis/Questions.js
@@ -7,7 +7,7 @@ const Questions = ({ questao, analysis, setDimensions, handleCheckBoxClick, hand
     useEffect(() => {
         // setQuest(questao)
         initAnswer()
-        console.log(questao.answer)
+        // console.log(questao.answer)
     },[])
 
     function initAnswer(){

--- a/Frontend/src/components/Analyst/analysis/Questions.js
+++ b/Frontend/src/components/Analyst/analysis/Questions.js
@@ -48,28 +48,18 @@ const Questions = ({ questao, analysis, setDimensions, handleCheckBoxClick, hand
         setActive(!active)
     }
 
-    // document.onload = initAnswer();
     return <>
             <script src="https://unpkg.com/react/umd/react.production.min.js"></script>
             <script src="https://unpkg.com/react-collapse/build/react-collapse.min.js"></script>
             <div className='question-container'>
 
-                {/* <div className='negative-container'> */}
-                    <button className='negative-btn' onClick={answerHandler}>
-                    <img src="../images/x.svg" alt="X"/>
-                    </button>
-                {/* </div> */}
+                <button className='negative-btn' onClick={answerHandler}>
+                <img src="../images/x.svg" alt="X"/>
+                </button>
                 
 
                 <div className='full-question-area'>
-                    {/* <div className='question-and-awnser'> */}
-                    
-                    {/* <UnmountClosed isOpened={active} initialStyle={{height: 0, overflow: 'hidden'}}>
-                        alooooooooooooooooooooooooooooooooooo
-                    </UnmountClosed> */}
 
-
-                    {/* <div className='alig-areas'> */}
                         <div className='questionArea' id={'question'+questao.id} onClick= {questionClickHandler}>
                             {questao.question.body} 
                         </div>
@@ -101,11 +91,11 @@ const Questions = ({ questao, analysis, setDimensions, handleCheckBoxClick, hand
                             </label>  */}
                     {/* </div> */}
                 </div>
-                {/* <div className='positive-container'> */}
-                    <button className='positive-btn' onClick={answerHandler}>
-                        <img src="../images/v.svg" alt="V"/>
-                    </button>   
-                {/* </div> */}
+
+                <button className='positive-btn' onClick={answerHandler}>
+                    <img src="../images/v.svg" alt="V"/>
+                </button>   
+
 
 
             </div>

--- a/Frontend/src/components/Analyst/analysis/Questions.js
+++ b/Frontend/src/components/Analyst/analysis/Questions.js
@@ -7,30 +7,56 @@ const Questions = ({ questao, analysis, setDimensions, handleCheckBoxClick, hand
     useEffect(() => {
         // setQuest(questao)
         initAnswer()
+        console.log(questao.answer)
     },[])
 
     function initAnswer(){
         var box = document.getElementById('question'+questao.id)
-        if (questao.answer){
+        if (questao.answer === 1){
             box.style.animation = "positive-neutral 0.125s linear forwards";
+            return;
         }
-        else{
+        // else{
+        if (questao.answer === 0){
             box.style.animation = "negative-neutral 0.125s linear forwards";
+            return;
         }
+        return;
+        // }
     }
          
-    function answerHandler(){
+    function answerHandler(answer){
         var box = document.getElementById('question'+questao.id)
-        if (questao.answer){
-            box.style.animation = "negative 0.125s linear forwards";
-            // questao.answer = !questao.answer
-            
+        console.log("answerhandler answer = " + answer)
+
+        if (questao.answer != true && questao.answer != false){
+            if (answer === true){
+                box.style.animation = "positive-neutral 0.125s linear forwards";
+            }
+            // else{
+            if (answer === false){
+                box.style.animation = "negative-neutral 0.125s linear forwards";
+            }
         }
         else{
-            box.style.animation = "positive 0.125s linear forwards";
-            // questao.answer = !questao.answer
+            answer = !answer
+
+            if (answer === false){
+                box.style.animation = "negative 0.125s linear forwards";
+                // questao.answer = !questao.answer
+                
+                
+            }
+            if (answer === true){
+                box.style.animation = "positive 0.125s linear forwards";
+                // questao.answer = !questao.answer  
+            }
+            
         }
-        handleCheckBoxClick(questao)
+
+        handleCheckBoxClick(questao,answer)
+
+        console.log("answerhandler answer final= " + answer)
 
     }
       
@@ -53,7 +79,7 @@ const Questions = ({ questao, analysis, setDimensions, handleCheckBoxClick, hand
             <script src="https://unpkg.com/react-collapse/build/react-collapse.min.js"></script>
             <div className='question-container'>
 
-                <button className='negative-btn' onClick={answerHandler}>
+                <button className='negative-btn' onClick={() => answerHandler(false)}>
                 <img src="../images/x.svg" alt="X"/>
                 </button>
                 
@@ -76,6 +102,7 @@ const Questions = ({ questao, analysis, setDimensions, handleCheckBoxClick, hand
                                 <textarea  className='sourceArea' id = {'questionSource'+questao.id} onChange={sourceAreaChange}>{questao.source}</textarea> <br></br>
                             </div>
                         </div> 
+                    
                     </Collapse>
 
 
@@ -92,9 +119,10 @@ const Questions = ({ questao, analysis, setDimensions, handleCheckBoxClick, hand
                     {/* </div> */}
                 </div>
 
-                <button className='positive-btn' onClick={answerHandler}>
+                <button className='positive-btn' onClick={() => answerHandler(true)}>
                     <img src="../images/v.svg" alt="V"/>
                 </button>   
+                
 
 
 

--- a/lanternaverde_web/models.py
+++ b/lanternaverde_web/models.py
@@ -242,7 +242,17 @@ class AvaliacaoAnalista(models.Model):
 
 class Questao(models.Model):
     question = models.ForeignKey(Pergunta, on_delete=models.CASCADE)
-    answer = models.BooleanField(default=False)
+    
+    NO = 0
+    YES = 1
+    N_A = 2
+    ANSWER_CHOICES = (
+        (NO,"no"),
+        (YES,"yes"),
+        (N_A,"not_answered")
+    )
+    
+    answer = models.IntegerField(choices=ANSWER_CHOICES, default= N_A)
     questionnaire = models.ForeignKey(AvaliacaoAnalista, on_delete=models.CASCADE)
     
     justification = models.TextField(blank=True)

--- a/lanternaverde_web/utils/countdimension.py
+++ b/lanternaverde_web/utils/countdimension.py
@@ -4,6 +4,6 @@ def _count_dimension(analysis):
     dimensions = {'D1': {'amount': 0, 'checked': 0}, 'D2': {'amount': 0, 'checked': 0}, 'D3': {'amount': 0, 'checked': 0}, 'D4': {'amount': 0, 'checked': 0}}
     for question in question_set:
         dimensions[question['question']['dimension']]['amount'] += 1
-        if question['answer']:
+        if question['answer'] == 1:
             dimensions[question['question']['dimension']]['checked'] += 1
     return dimensions


### PR DESCRIPTION
Nessa Pull Request foi implementada a barra de progresso na tela do preenchimento do questionário por parte do analista para que ele possa ter uma noção de quantas perguntas faltam para que ele responda todas as questões:
![image](https://user-images.githubusercontent.com/84993974/197547617-cc759acd-c4cd-4444-b29a-7d241cdb88fc.png)



## Problema

O problema é que atualmente, o analista não tem nenhuma dica ou indicação visual do seu progresso em uma análise específica, isso fazia com que o progresso do preenchimento do formulário pudesse ser facilmente esquecido pelo analista, já que ele não teria nenhum recurso visual que o indicasse o quanto ainda lhe faltava para a finalização de uma análise.

## Implementação

Antes de mais nada, vale apontar que foram necessários alguns ajustes no backend do projeto, para que fosse possivel a adequação das novas features no projeto. Primeiramente o modelo da questão foi alterado, onde o atributo "answer" da mesma, passou de um booleano para um inteiro, podendo receber três valores diferentes, sendo eles (0, 1, 2) onde eles representam, respectivamente (resposta negativa, resposta positiva, ainda não respondido) poís existia essa necessidade de saber quando uma resposa foi respondida ou não, além claro de saber qual foi a resposta dada pelo analísta. A modificação foi a seguinte:
![image](https://user-images.githubusercontent.com/84993974/197549169-3343f42d-9910-4d94-8571-e429d34df056.png)
Para:
![image](https://user-images.githubusercontent.com/84993974/197549272-133d24a7-93af-41aa-b6f7-f65278ef8aaa.png)

Também foi necessário mudar o valor padrão das respostas de cada pergunta, passando de "false" (ou seja, por padrão todas as respostas eram marcadas como negativas) para o valor 2 (ou seja, "not_answered"):
![image](https://user-images.githubusercontent.com/84993974/197549948-3e7b95a7-bfea-4fc5-a308-ce14d4b76526.png)

Também foi necessário fazer uma pequena modificação no backend no arquivo countdimension.py para que a contagem das dimensões fosse feita de forma correta, para isso apenas modifiquei a condicional, onde agora só seria contabilizado caso a resposta fosse igual a 1 (o que indicaria que a pergunta foi respondida positivamente):
![image](https://user-images.githubusercontent.com/84993974/197550405-88e755bf-af4a-4270-90ca-0e2500763604.png)

Já na parte do frontend, algumas coisas foram adicionadas e alteradas. Primeiramente a barra de progresso que foi utilizada foi a ProgressBar do proprio react. Nessa parte não houve nenhuma dificuldade de implementa-lá, já que é apenas um componente já montado. Agora para a utilização do valor que será introduzido na barra, foi necessário a adição de um novo state chamado "analysisCountRate" que sempre será calculado da seguinte forma:
((Numero de questões respondidas) / (Numero total de questões)) * 100)
![image](https://user-images.githubusercontent.com/84993974/197551152-7cf5aab5-6ed9-4dc0-b0f8-2c325dccd121.png)

Que resulta em:
![image](https://user-images.githubusercontent.com/84993974/197551286-b1d0d48e-02ca-4e56-9372-00dfe00224c9.png)





## Como Testar
Antes de mais nada, como foram necessários algumas alterações no backend, sugiro que delete sua base de dados anterior e faça as migrações necessárias do Django com os seguintes comandos:
  python manage.py makemigrations
  python manage.py migrate --run-syncdb

E em seguida faça os comandos padrões antes de iniciar o servidor:
  python manage.py createsuperuser
  python manage.py runscript populate_gas_questions
  python manage.py runserver

Primeiramente faça login como analista e abra uma das suas analises ainda não finalizada e veja se a nova barra de progresso aparece para você. Você deve ver algo parecido com isto:
![image](https://user-images.githubusercontent.com/84993974/197552334-6ddde68d-54b3-4c5c-ab76-839cbc902283.png)

Agora note também que, as questões que você ainda não respondeu, não estão nem para a direita nem para a esquerda, e sim no centro, indicando que ainda não foram respondidas:

![image](https://user-images.githubusercontent.com/84993974/197552498-3f064181-bbb9-4288-a42b-44e171eebfde.png)

Agora selecione as respostas das questões ainda não respondidas e veja se a barra de progresso aumenta a medida que você as responde, de maneira semelhante ao GIF abaixo: 

![gif-barra-progresso 00_00_00-00_00_30~1](https://user-images.githubusercontent.com/84993974/197559627-a3830500-b59e-4149-a49a-1f470b029bb6.gif)


## Notas do desenvolvedor

Foram necessárias alterações e adições tanto no frontend quanto no backend.

## Objetivos

Fix #83 
Fix #93 
