### PR TITLE
[Chore] Back-end permite acesso apenas a porta 3000

### DIFF
--- a/lanternaverde/settings.py
+++ b/lanternaverde/settings.py
@@ -58,12 +58,9 @@ MIDDLEWARE = [
 
 CSRF_TRUSTED_ORIGINS = ['http://localhost:3000']
 
-CORS_ALLOW_ALL_ORIGINS = True
+CORS_ORIGIN_ALLOW_ALL = False
 CORS_ALLOW_CREDENTIALS = True
-CORS_ALLOWED_ORIGINS = [
-    'http://localhost:3000',
-    'http://127.0.0.1:3000',
-]
+CORS_ORIGIN_WHITELIST = ('http://localhost:3000',)
 
 ROOT_URLCONF = 'lanternaverde.urls'
 


### PR DESCRIPTION
<!-- Está criando uma Pull Request pela primeira vez? Deixe esse modelo guiar você -->

Nesta PR é feita uma modificação para permitir o acesso apenas às requisições feitas pela porta 3000
<!-- Nesse campo faça um pequeno sumário das suas implementações e seja breve, deixe para detalhar nos campos mais específicos. -->

## Problema

Durante o desenvolvimento precisávamos utilizar origens diferentes de requisições para fazer testes, mas o ideal é que sejam permitidas apenas requisições originadas do nosso frontend

## Implementação

No arquivo `settings.py` foram feitas algumas modificações, configurando o CORS (Cross-Origin Resource Sharing), para que seja permitido o acesso à nossa API Rest pelo React, e não mais permitindo todos os hosts

## Como testar
Pode-se fazer o teste realizando algumas requisições a partir da aplicação React, e também observar que se o endereço `http://localhost:3000` for removido da linha [63](https://github.com/Engenharia-de-Software-UFRPE/lanterna-verde/pull/99/files#diff-6a5890dabbb05985410eb0fb41d7eaa0a0455bd6d23fd19b908845a22ebeff17R63) do arquivo `settings.py`, haverá um bloqueio no lado do cliente

### Referência
[How to enable CORS headers in your Django Project?](https://www.geeksforgeeks.org/how-to-enable-cors-headers-in-your-django-project/)